### PR TITLE
(feat) UHM-8241 add back button for O2 iframe navigation and hide/dis…

### DIFF
--- a/packages/esm-commons-app/package.json
+++ b/packages/esm-commons-app/package.json
@@ -18,7 +18,7 @@
     "test:watch": "cross-env TZ=UTC jest --watch --config jest.config.js --color",
     "coverage": "yarn test --coverage",
     "typescript": "tsc",
-    "extract-translations": "i18next 'src/**/*.component.tsx'"
+    "extract-translations": "i18next 'src/**/*.component.tsx' 'src/**/*.extension.tsx' 'src/**/*modal.tsx' 'src/**/*.workspace.tsx' 'src/index.ts' --config ../../tools/i18next-parser.config.js"
   },
   "browserslist": [
     "extends browserslist-config-openmrs"

--- a/packages/esm-commons-app/src/hooks/useProgramEnrollment.ts
+++ b/packages/esm-commons-app/src/hooks/useProgramEnrollment.ts
@@ -1,0 +1,19 @@
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import useSWR from 'swr';
+const customRepresentation = `custom:(uuid,display,program,dateEnrolled,dateCompleted,location:(uuid,display))`;
+
+export interface PatientProgram {
+  uuid: string;
+  program: {
+    uuid: string;
+  };
+}
+
+export const useActivePatientEnrollment = (patientUuid: string) => {
+  const result = useSWR<{ data: { results: Array<PatientProgram> } }>(
+    patientUuid ? `${restBaseUrl}/programenrollment?patient=${patientUuid}&v=${customRepresentation}` : null,
+    openmrsFetch,
+  );
+
+  return result;
+};

--- a/packages/esm-commons-app/src/ward-app/o2-iframe.component.tsx
+++ b/packages/esm-commons-app/src/ward-app/o2-iframe.component.tsx
@@ -1,0 +1,77 @@
+import { ArrowLeft } from '@carbon/react/icons';
+
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import styles from './o2-iframe.scss';
+import { IconButton, InlineLoading } from '@carbon/react';
+import { useTranslation } from 'react-i18next';
+
+interface O2IFrame {
+  src: string;
+  /**
+   * a list of css selectors defining elements to hide within the iframe
+   */
+  elementsToHide?: string[];
+
+  /**
+   * a list of css selectors defining elements to be made un-clickable within the iframe
+   */
+  elementsToDisable?: string[];
+}
+
+const O2IFrame: React.FC<O2IFrame> = ({ src, elementsToHide, elementsToDisable }) => {
+  const iframeRef = useRef<HTMLIFrameElement>();
+  const [isIframeLoading, setIsIframeLoading] = useState(true);
+  const [isGoingBack, setIsGoingBack] = useState(false);
+  const [iframeHistoryCount, setIframeHistoryCount] = useState(0);
+  const { t } = useTranslation();
+
+  const customCss = useMemo(() => {
+    const toHide = elementsToHide?.map((e) => `${e} {display: none !important;}`)?.join('\n') ?? '';
+    const toDisable =
+      elementsToDisable?.map((e) => `${e} {pointer-events: none; cursor: not-allowed;}`)?.join('\n') ?? '';
+
+    return `@media screen {
+        ${toHide}
+        ${toDisable}
+      }`;
+  }, [elementsToHide, elementsToDisable]);
+
+  const onLoad = () => {
+    setIsIframeLoading(false);
+    if (!isGoingBack) {
+      setIframeHistoryCount(iframeHistoryCount + 1);
+    }
+    setIsGoingBack(false);
+    iframeRef.current.contentWindow.addEventListener('beforeunload', () => setIsIframeLoading(true));
+    const contentDocument = iframeRef.current.contentDocument;
+
+    const styleTag = contentDocument.createElement('style');
+    styleTag.innerHTML = customCss;
+    contentDocument.head.appendChild(styleTag);
+  };
+
+  const goBack = () => {
+    iframeRef.current.contentWindow.history.back();
+    setIframeHistoryCount(iframeHistoryCount - 1);
+    setIsIframeLoading(true);
+    setIsGoingBack(true);
+  };
+
+  return (
+    <div className={styles.iframeWrapper}>
+      <div className={styles.navigation}>
+        <IconButton
+          align="top-start"
+          label={t('back', 'Back')}
+          onClick={goBack}
+          disabled={isIframeLoading || iframeHistoryCount <= 1}>
+          <ArrowLeft />
+        </IconButton>
+        {isIframeLoading && <InlineLoading />}
+      </div>
+      <iframe ref={iframeRef} src={src} onLoad={onLoad} className={styles.o2Iframe} />
+    </div>
+  );
+};
+
+export default O2IFrame;

--- a/packages/esm-commons-app/src/ward-app/o2-iframe.scss
+++ b/packages/esm-commons-app/src/ward-app/o2-iframe.scss
@@ -5,9 +5,16 @@
 .iframeWrapper {
   height: 100%;
   width: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .o2Iframe {
   height: 100%;
   width: 100%;
+}
+
+.navigation {
+  display: flex;
+  flex: 1;
 }

--- a/packages/esm-commons-app/src/ward-app/o2-pregnancy-infant-dashboard.extension.tsx
+++ b/packages/esm-commons-app/src/ward-app/o2-pregnancy-infant-dashboard.extension.tsx
@@ -1,55 +1,67 @@
-import { useAppContext } from '@openmrs/esm-framework';
-import React, { useCallback, useRef } from 'react';
-import styles from './o2-pregnancy-infant-dashboard.scss';
-import { type MaternalWardViewContext } from './types';
+import { InlineLoading } from '@carbon/react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useActivePatientEnrollment } from '../hooks/useProgramEnrollment';
+import O2IFrame from './o2-iframe.component';
 
 /**
  * Extension to display either the O2 pregnancy program or infant program dashboard,
- * depending on whether patient is mother or infant.
+ * if the patient is enrolled in it.
  */
 const O2PregnancyInfantProgramDashboard: React.FC<{ patientUuid: string }> = ({ patientUuid }) => {
-  const iframeRef = useRef<HTMLIFrameElement>();
-
-  const { motherChildRelationships } = useAppContext<MaternalWardViewContext>('maternal-ward-view-context') ?? {};
-  const isInfant = motherChildRelationships?.motherByChildUuid?.has(patientUuid);
-
   const infantProgramUuid = 'dc1b588a-9b94-45e4-8346-71b7c9a24845';
   const pregnancyProgramUuid = '6a5713c2-3fd5-46e7-8f25-36a0f7871e12';
-  const dashboardUuid = isInfant ? infantProgramUuid : pregnancyProgramUuid;
 
-  // hide the headers, breadcrumbs and various sections of the dashboards
-  const onLoad = useCallback(() => {
-    const dashboard = iframeRef.current.contentDocument;
-    const elementsToHide = [
-      'header',
-      '.patient-header',
-      '#breadcrumbs',
-      '.action-section',
-      '.visits-section',
-      '.pregnancy\\.dashboard\\.ancInitialEncounters',
-      '.pregnancy\\.dashboard\\.ancFollowupEncounters',
-      '.patient-location',
-      '.pregnancy\\.dashboard\\.currentEnrollment',
-      '.infant\\.dashboard\\.newbornAssesmentEncounters',
-      '.infant\\.dashboard\\.newbornDailyProgressEncounters',
-      '.infant\\.dashboard\\.currentEnrollment',
-      '.program-history',
-    ];
+  const { data: programs, isLoading } = useActivePatientEnrollment(patientUuid);
+  const { t } = useTranslation();
 
-    const styleTag = dashboard.createElement('style');
-    styleTag.innerHTML = elementsToHide.map((e) => `${e} {display: none !important;}`).join('\n');
-    dashboard.head.appendChild(styleTag);
-  }, []);
+  const inInfantProgram = programs?.data?.results?.some((enrollment) => enrollment.program.uuid == infantProgramUuid);
+  const inPregnancyProgram = programs?.data?.results?.some(
+    (enrollment) => enrollment.program.uuid == pregnancyProgramUuid,
+  );
 
-  if (patientUuid) {
-    const src = `${window.openmrsBase}/coreapps/clinicianfacing/patient.page?patientId=${patientUuid}&dashboard=${dashboardUuid}`;
+  const elementsToHide = [
+    'header',
+    '.patient-header',
+    '#breadcrumbs',
+    '.action-section',
+    '.visits-section',
+    '.pregnancy\\.dashboard\\.ancInitialEncounters',
+    '.pregnancy\\.dashboard\\.ancFollowupEncounters',
+    '.pregnancy\\.dashboard\\.riskFactors a.right',
+    '.pregnancy\\.dashboard\\.temperature a.right',
+    '.patient-location',
+    '.pregnancy\\.dashboard\\.currentEnrollment',
+    '.infant\\.dashboard\\.newbornAssesmentEncounters',
+    '.infant\\.dashboard\\.newbornDailyProgressEncounters',
+    '.infant\\.dashboard\\.currentEnrollment',
+    '.program-history',
+    '.allergies .cancel',
+  ];
+
+  const elementsToDisable = [
+    '.pregnancy\\.dashboard\\.riskFactors a',
+    '.pregnancy\\.dashboard\\.temperature a',
+    '.infant\\.dashboard\\.indicator a',
+  ];
+
+  if (isLoading) {
+    return <InlineLoading />;
+  } else if (inInfantProgram) {
+    const src = `${window.openmrsBase}/coreapps/clinicianfacing/patient.page?patientId=${patientUuid}&dashboard=${infantProgramUuid}`;
+    return <O2IFrame key={patientUuid} {...{ src, elementsToDisable, elementsToHide }} />;
+  } else if (inPregnancyProgram) {
+    const src = `${window.openmrsBase}/coreapps/clinicianfacing/patient.page?patientId=${patientUuid}&dashboard=${pregnancyProgramUuid}`;
+    return <O2IFrame key={patientUuid} {...{ src, elementsToDisable, elementsToHide }} />;
+  } else {
     return (
-      <div className={styles.iframeWrapper} key={patientUuid}>
-        <iframe ref={iframeRef} src={src} onLoad={onLoad} className={styles.o2Iframe} />
+      <div>
+        {t(
+          'patientNotEnrolledInInfantOrPregnancyProgram',
+          'Patient not enrolled in either Infant or Pregnancy Program',
+        )}
       </div>
     );
-  } else {
-    return;
   }
 };
 

--- a/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.component.tsx
+++ b/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.component.tsx
@@ -1,30 +1,35 @@
-import React, { useCallback, useRef } from 'react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import O2IFrame from './o2-iframe.component';
 import { type WardPatientWorkspaceProps } from './types';
-import styles from './o2-visit-summary-workspace.scss';
+
+const LABOUR_DELIVERY_SUMMARY_ENCOUNTER_TYPE = 'fec2cc56-e35f-42e1-8ae3-017142c1ca59';
+const MATERNAL_ADMISSION_ENCOUNTER_TYPE = '0ef67d23-0cf4-4a3e-8617-ac9d55bdd005';
+const POSTPARTUM_DAILY_PROGRESS = '37f04ddf-9653-4a02-98b4-1c23734c2f15';
+
+const toClass = (encounterUuid: string) => '.encounterType-' + encounterUuid;
 
 const O2VisitSummaryWorkspace: React.FC<WardPatientWorkspaceProps> = ({ wardPatient }) => {
   const { patient, visit } = wardPatient ?? {};
-  const iframeRef = useRef<HTMLIFrameElement>();
 
-  // hide the headers breadcrumbs and visit actions from
-  const onLoad = useCallback(() => {
-    const dashboard = iframeRef.current.contentDocument;
-    const elementsToHide = ['header', '.patient-header', '#breadcrumbs', '.visit-actions', '#choose-another-visit'];
+  const { t } = useTranslation();
 
-    const styleTag = dashboard.createElement('style');
-    styleTag.innerHTML = elementsToHide.map((e) => `${e} {display: none;}`).join('\n');
-    dashboard.head.appendChild(styleTag);
-  }, []);
+  const elementsToHide = [
+    'header',
+    '.patient-header',
+    '#breadcrumbs',
+    '.visit-actions',
+    '#choose-another-visit',
+    toClass(LABOUR_DELIVERY_SUMMARY_ENCOUNTER_TYPE),
+    toClass(MATERNAL_ADMISSION_ENCOUNTER_TYPE),
+    toClass(POSTPARTUM_DAILY_PROGRESS),
+  ];
 
   if (patient && visit) {
     const src = `${window.openmrsBase}/pihcore/visit/visit.page?patient=${patient.uuid}&visit=${visit.uuid}`;
-    return (
-      <div className={styles.iframeWrapper}>
-        <iframe ref={iframeRef} src={src} onLoad={onLoad} className={styles.o2Iframe} />
-      </div>
-    );
+    return <O2IFrame src={src} elementsToHide={elementsToHide} />;
   } else {
-    return;
+    return <div>{t('patientHasNoActiveVisit', 'Patient has no active visit')}</div>;
   }
 };
 

--- a/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.scss
+++ b/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.scss
@@ -1,9 +1,0 @@
-.iframeWrapper {
-  height: 100%;
-  width: 100%;
-}
-
-.o2Iframe {
-  height: 100%;
-  width: 100%;
-}

--- a/packages/esm-commons-app/translations/en.json
+++ b/packages/esm-commons-app/translations/en.json
@@ -1,4 +1,7 @@
 {
+  "back": "Back",
+  "patientHasNoActiveVisit": "Patient has no active visit",
+  "patientNotEnrolledInInfantOrPregnancyProgram": "Patient not enrolled in either Infant or Pregnancy Program",
   "patientVisitSummary": "Patient visit summary",
   "visitSummary": "Visit summary"
 }


### PR DESCRIPTION
…able various elements in dashboards

## Summary
- Add a back button and a loading indicator for navigation within the iframe
- Remove the following in the visits summary:
  - Postpartum Daily Progress
  - Labor and Delivery Summary
  - Maternal Admission

In Infant dash:
  - Remove arrow link and disable date link in the Temperature widget
  - disable link to mother's chart in "Newborn Indicators" widget

In Pregnancy dash:
- Remove arrow link and disable date link in the Risk Factor widget
- removed "Return" button from allergies
## Screenshots
![image](https://github.com/user-attachments/assets/59e3752a-c4b5-492a-b725-688198fac8dc)
![image](https://github.com/user-attachments/assets/b33248f7-a59f-423a-8cca-ff0c4d54ca18)

## Related Issue
https://pihemr.atlassian.net/browse/UHM-8241