### PR TITLE
(fix) UHM-8319 - Fix O2 Visit Summary workspace not loading

### DIFF
--- a/packages/esm-commons-app/src/routes.json
+++ b/packages/esm-commons-app/src/routes.json
@@ -22,7 +22,8 @@
       "type": "o2-visit-summary",
       "sidebarFamily": "ward-patient",
       "hasOwnSidebar": true,
-      "width": "extra-wide"
+      "width": "extra-wide",
+      "groups": ["ward-patient"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
The Workspace API had a backward-incompatible change recently, and it broke the O2 Visit Summary workspace. This PR fixes it.
 
## Screenshots

## Related Issue
