### PR TITLE
(fix) UHM-8240 make visit summary left nav always show

### DIFF
--- a/packages/esm-commons-app/src/ward-app/o2-iframe.component.tsx
+++ b/packages/esm-commons-app/src/ward-app/o2-iframe.component.tsx
@@ -16,9 +16,14 @@ interface O2IFrame {
    * a list of css selectors defining elements to be made un-clickable within the iframe
    */
   elementsToDisable?: string[];
+
+  /**
+   * JavaScript code to inject into the iframe to run
+   */
+  customJavaScript?: string;
 }
 
-const O2IFrame: React.FC<O2IFrame> = ({ src, elementsToHide, elementsToDisable }) => {
+const O2IFrame: React.FC<O2IFrame> = ({ src, elementsToHide, elementsToDisable, customJavaScript = '' }) => {
   const iframeRef = useRef<HTMLIFrameElement>();
   const [isIframeLoading, setIsIframeLoading] = useState(true);
   const [isGoingBack, setIsGoingBack] = useState(false);
@@ -32,7 +37,7 @@ const O2IFrame: React.FC<O2IFrame> = ({ src, elementsToHide, elementsToDisable }
 
     return `@media screen {
         ${toHide}
-        ${toDisable}
+        ${toDisable} 
       }`;
   }, [elementsToHide, elementsToDisable]);
 
@@ -48,6 +53,10 @@ const O2IFrame: React.FC<O2IFrame> = ({ src, elementsToHide, elementsToDisable }
     const styleTag = contentDocument.createElement('style');
     styleTag.innerHTML = customCss;
     contentDocument.head.appendChild(styleTag);
+
+    const scriptTag = contentDocument.createElement('script');
+    scriptTag.innerHTML = customJavaScript;
+    contentDocument.body.appendChild(scriptTag);
   };
 
   const goBack = () => {

--- a/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.component.tsx
+++ b/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.component.tsx
@@ -24,10 +24,15 @@ const O2VisitSummaryWorkspace: React.FC<WardPatientWorkspaceProps> = ({ wardPati
     toClass(MATERNAL_ADMISSION_ENCOUNTER_TYPE),
     toClass(POSTPARTUM_DAILY_PROGRESS),
   ];
+  const customJavaScript = `
+    $('#formBreadcrumb').show();
+    $('.simple-form-ui form section').width(300);
+    $('#nav-buttons').hide();
+  `;
 
   if (patient && visit) {
     const src = `${window.openmrsBase}/pihcore/visit/visit.page?patient=${patient.uuid}&visit=${visit.uuid}`;
-    return <O2IFrame src={src} elementsToHide={elementsToHide} />;
+    return <O2IFrame src={src} elementsToHide={elementsToHide} customJavaScript={customJavaScript} />;
   } else {
     return <div>{t('patientHasNoActiveVisit', 'Patient has no active visit')}</div>;
   }

--- a/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.component.tsx
+++ b/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.component.tsx
@@ -25,9 +25,9 @@ const O2VisitSummaryWorkspace: React.FC<WardPatientWorkspaceProps> = ({ wardPati
     toClass(POSTPARTUM_DAILY_PROGRESS),
   ];
   const customJavaScript = `
-    $('#formBreadcrumb').show();
-    $('.simple-form-ui form section').width(300);
-    $('#nav-buttons').hide();
+    jQuery('#formBreadcrumb').show();
+    jQuery('.simple-form-ui form section').width(300);
+    jQuery('#nav-buttons').hide();
   `;
 
   if (patient && visit) {


### PR DESCRIPTION
## Summary
Turns out it's much easier to do this here.

The visit summary workspace is missing the patient header. I will fix it in a different ticket.

## Screenshots
![image](https://github.com/user-attachments/assets/4ccd5494-aa32-48df-8c0e-b069bd14afca)

## Related Issue
