### PR TITLE
UHM-8242 mount dispensing dashboard without left nav on different URL

### DIFF
--- a/packages/esm-commons-app/src/root.component.tsx
+++ b/packages/esm-commons-app/src/root.component.tsx
@@ -8,6 +8,7 @@ export default function Root() {
       <BrowserRouter basename={window.spaBase}>
         <Routes>
           <Route path="/appointments" element={<Appointments />} />
+          <Route path="/dispensing2" element={<Dispensing />} />
           <Route path="/service-queues/queue-table-by-status/:queueUuid" element={<QueueTableByStatus />} />
           <Route path="/ward" element={<Ward />} />
         </Routes>
@@ -21,6 +22,19 @@ function Appointments() {
     <>
       <WorkspaceContainer overlay contextKey="appointments" />
       <ExtensionSlot name={'appointments-dashboard-slot'} />
+    </>
+  );
+}
+
+/**
+ * This is mounted at /dispensing2 instead of /dispensing. It's basically the same thing
+ * but without the collapsed left nav.
+ */
+function Dispensing() {
+  return (
+    <>
+      <WorkspaceContainer overlay contextKey="dispensing2" />
+      <ExtensionSlot name={'dispensing-dashboard-slot'} />
     </>
   );
 }

--- a/packages/esm-commons-app/src/routes.json
+++ b/packages/esm-commons-app/src/routes.json
@@ -3,15 +3,19 @@
   "pages": [
     {
       "component": "root",
-      "route": "ward"
-    },
-    {
-      "component": "root",
       "route": "appointments"
     },
     {
       "component": "root",
       "route": "service-queues"
+    },
+    {
+      "component": "root",
+      "route": "dispensing2"
+    },
+    {
+      "component": "root",
+      "route": "ward"
     }
   ],
   "extensions": [


### PR DESCRIPTION
## Summary
Mount the dispensing dashboard onto the commons app, so we can render the app without the left nav.

## Screenshots

## Related Issue
