### PR TITLE
UHM-8241 remove code to hide various encounter types in O2 visit summary

### DIFF
--- a/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.component.tsx
+++ b/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.component.tsx
@@ -2,18 +2,7 @@ import { ExtensionSlot } from '@openmrs/esm-framework';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import O2IFrame from './o2-iframe.component';
-import type { WardPatient, WardPatientWorkspaceProps } from './types';
-
-const LABOUR_DELIVERY_SUMMARY_ENCOUNTER_TYPE = 'fec2cc56-e35f-42e1-8ae3-017142c1ca59';
-const MATERNAL_ADMISSION_ENCOUNTER_TYPE = '0ef67d23-0cf4-4a3e-8617-ac9d55bdd005';
-const POSTPARTUM_DAILY_PROGRESS = '37f04ddf-9653-4a02-98b4-1c23734c2f15';
-
-const toClass = (encounterUuid: string) => '.encounterType-' + encounterUuid;
-
-// partial type defined in esm-ward-app
-interface WardViewContext {
-  WardPatientHeader: React.FC<{ wardPatient: WardPatient }>;
-}
+import type { WardPatientWorkspaceProps } from './types';
 
 const O2VisitSummaryWorkspace: React.FC<WardPatientWorkspaceProps> = (props) => {
   const { wardPatient } = props;
@@ -21,16 +10,7 @@ const O2VisitSummaryWorkspace: React.FC<WardPatientWorkspaceProps> = (props) => 
 
   const { t } = useTranslation();
 
-  const elementsToHide = [
-    'header',
-    '.patient-header',
-    '#breadcrumbs',
-    '.visit-actions',
-    '#choose-another-visit',
-    toClass(LABOUR_DELIVERY_SUMMARY_ENCOUNTER_TYPE),
-    toClass(MATERNAL_ADMISSION_ENCOUNTER_TYPE),
-    toClass(POSTPARTUM_DAILY_PROGRESS),
-  ];
+  const elementsToHide = ['header', '.patient-header', '#breadcrumbs', '.visit-actions', '#choose-another-visit'];
   const customJavaScript = `
     jQuery('#formBreadcrumb').show();
     jQuery('.simple-form-ui form section').width(400);


### PR DESCRIPTION
## Summary
I mistaken hide these encounter types instead of hiding the appropriate sections in the pregnancy dash. This PR fixes it. See https://pihemr.atlassian.net/browse/UHM-8241

## Screenshots

## Related Issue
