### PR TITLE
SL-1188 fix react-i18next version in esm-commons-app

### DIFF
--- a/packages/esm-commons-app/package.json
+++ b/packages/esm-commons-app/package.json
@@ -44,8 +44,8 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "i18next": "^19.0.0",
-    "react": "18.x"
+    "react": "18.x",
+    "react-i18next": "16.x"
   },
   "devDependencies": {
     "webpack": "^5.74.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4215,8 +4215,8 @@ __metadata:
     webpack: "npm:^5.74.0"
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    i18next: ^19.0.0
     react: 18.x
+    react-i18next: 16.x
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary
We were using a wrong version of i18next and string interpolation was not done working.

## Screenshots
Before:
<img width="1024" height="491" alt="image" src="https://github.com/user-attachments/assets/f9a8d5d9-d885-44e0-ae0c-8b5c0de72cc1" />

After:

[Screencast from 2026-02-19 13-28-28.webm](https://github.com/user-attachments/assets/71ad9d0b-f159-4343-a681-a2645de8d435)

## Related Issue
