### PR TITLE
SL-1088 prevent double discharge of patient from the ward app

### DIFF
--- a/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.component.tsx
+++ b/packages/esm-commons-app/src/ward-app/o2-visit-summary-workspace.component.tsx
@@ -1,11 +1,18 @@
-import { ExtensionSlot, Workspace2 } from '@openmrs/esm-framework';
-import React from 'react';
+import {
+  closeWorkspaceGroup2,
+  ExtensionSlot,
+  openmrsFetch,
+  restBaseUrl,
+  showSnackbar,
+  Workspace2,
+} from '@openmrs/esm-framework';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import O2IFrame from './o2-iframe.component';
 import type { WardPatientWorkspaceDefinition } from './types';
 
 const O2VisitSummaryWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({ groupProps: { wardPatient } }) => {
-  const { patient, visit } = wardPatient ?? {};
+  const { patient, visit, inpatientAdmission } = wardPatient ?? {};
 
   const { t } = useTranslation();
 
@@ -14,7 +21,41 @@ const O2VisitSummaryWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({ gro
     jQuery('#formBreadcrumb').show();
     jQuery('.simple-form-ui form section').width(400);
     jQuery('#nav-buttons').hide();
+
+    jQuery(document).ajaxComplete(function(event, xhr, settings) {
+      if (settings.type && settings.type.toUpperCase() === 'POST') {
+        window.parent.postMessage({ type: 'o2IframeFormSubmit' }, '*');
+      }
+    });
   `;
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.type === 'o2IframeFormSubmit') {
+        // check whether patient is still admitted. If not, close the workspace group
+        openmrsFetch(
+          `${restBaseUrl}/emrapi/inpatient/admission?patients=${patient?.uuid}&currentInpatientLocation=${inpatientAdmission?.currentInpatientLocation?.uuid}`,
+        )
+          .then((response) => {
+            if (response.ok && response.data.results.length === 0) {
+              closeWorkspaceGroup2();
+              showSnackbar({
+                title: t('patientDischarged', 'Patient discharged'),
+                subtitle: t('patientDischargedMessage', '{{patientName}} has been discharged from the ward.', {
+                  patientName: patient.person.display,
+                }),
+                kind: 'success',
+              });
+            }
+          })
+          .catch((error) => {
+            console.error('Error checking inpatient admission status:', error);
+          });
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
 
   const iframeSrc =
     patient && visit

--- a/packages/esm-commons-app/src/ward-app/types.ts
+++ b/packages/esm-commons-app/src/ward-app/types.ts
@@ -1,10 +1,11 @@
-import type { Patient, Visit, Workspace2DefinitionProps } from '@openmrs/esm-framework';
+import type { Patient, Visit, Location, Workspace2DefinitionProps } from '@openmrs/esm-framework';
 
 // stripped down versions of the same types defined in esm-ward-app
 
 export type WardPatient = {
   patient: Patient;
   visit: Visit;
+  inpatientAdmission: InpatientAdmission;
   // other fields not typed
 };
 
@@ -23,4 +24,8 @@ export interface MotherChildRelationships {
 
 export interface MaternalWardViewContext {
   motherChildRelationships: MotherChildRelationships;
+}
+export interface InpatientAdmission {
+  currentInpatientLocation: Location;
+  // other fields not typed
 }

--- a/packages/esm-commons-app/translations/en.json
+++ b/packages/esm-commons-app/translations/en.json
@@ -7,6 +7,8 @@
   "fullPatientChart": "Full patient chart",
   "fullPregnancyDashboard": "Full Pregnancy Dashboard",
   "maternalTriageForm": "Maternal triage form",
+  "patientDischarged": "Patient discharged",
+  "patientDischargedMessage": "{{patientName}} has been discharged from the ward.",
   "patientHasNoActiveVisit": "Patient has no active visit",
   "removePatient": "Remove patient",
   "transition": "Transition",


### PR DESCRIPTION
## Summary

When the user submits a O2 form to discharge a patient, on success, we should also close the workspace side nav so the user cannot accidentally open and submit the O3 discharge form as well.
We do this by checking whenever the iframe submits a POST request whether the patient is still admitted.

## Screenshots
Before:
[Screencast from 2026-03-05 12-39-04.webm](https://github.com/user-attachments/assets/57f79148-2172-47ea-9147-55b84d7cde05)
After:
[Screencast from 2026-03-05 13-58-26.webm](https://github.com/user-attachments/assets/29ef8cb0-26d8-425c-bafe-7d74b5c58b0e)

## Related Issue
