### PR TITLE
UHM-9062 Add E2E tests for Ward App admission workflows

### DIFF
--- a/e2e/commands/index.ts
+++ b/e2e/commands/index.ts
@@ -1,0 +1,3 @@
+export * from './location-operations';
+export * from './patient-operations';
+export * from './visit-operations';

--- a/e2e/commands/location-operations.ts
+++ b/e2e/commands/location-operations.ts
@@ -1,0 +1,22 @@
+import { type APIRequestContext, expect } from '@playwright/test';
+
+/**
+ * Mostly taken from openmrs-esm-patient-management
+ */
+
+export const changeLocation = async (api: APIRequestContext, locationUuid: string) => {
+  const locationRes = await api.post('session', {
+    data: {
+      sessionLocation: locationUuid,
+    },
+  });
+  await expect(locationRes.ok()).toBeTruthy();
+};
+
+export const changeToWardLocation = async (api: APIRequestContext) => {
+  return changeLocation(api, process.env.E2E_WARD_LOCATION_UUID as string);
+};
+
+export const changeToDefaultLocation = async (api: APIRequestContext) => {
+  return changeLocation(api, process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID as string);
+};

--- a/e2e/commands/location-operations.ts
+++ b/e2e/commands/location-operations.ts
@@ -12,11 +12,3 @@ export const changeLocation = async (api: APIRequestContext, locationUuid: strin
   });
   await expect(locationRes.ok()).toBeTruthy();
 };
-
-export const changeToWardLocation = async (api: APIRequestContext) => {
-  return changeLocation(api, process.env.E2E_WARD_LOCATION_UUID as string);
-};
-
-export const changeToDefaultLocation = async (api: APIRequestContext) => {
-  return changeLocation(api, process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID as string);
-};

--- a/e2e/commands/patient-operations.ts
+++ b/e2e/commands/patient-operations.ts
@@ -1,0 +1,143 @@
+import { type Patient } from '@openmrs/esm-framework';
+import { type APIRequestContext, expect } from '@playwright/test';
+import { KGHEmrIdSourceUuid, KGHEmrIdTypeUuid } from '../core/constants';
+
+/**
+ * Mostly taken from openmrs-esm-patient-management
+ */
+type PatientProfile = 'adultWomen' | 'adultMen' | 'newborn';
+
+function getPatientInfoFromProfile(profile: PatientProfile) {
+  switch (profile) {
+    case 'adultWomen':
+      return {
+        gender: 'F',
+        givenName: `Jane${new Date().toISOString()}`,
+        familyName: `Doe E2E`,
+        birthdate: getRandomBirthday(profile),
+      };
+    case 'adultMen':
+      return {
+        gender: 'M',
+        givenName: `John${new Date().toISOString()}`,
+        familyName: `Doe E2E`,
+        birthdate: getRandomBirthday(profile),
+      };
+    case 'newborn':
+      return {
+        gender: 'F',
+        givenName: `Baby${new Date().toISOString()}`,
+        familyName: `Doe E2E`,
+        birthdate: getRandomBirthday(profile),
+      };
+    default:
+      throw new Error(`Unknown patient profile: ${profile}`);
+  }
+}
+
+// return a YYYY-MM-DD string base on profile
+// adult - 18 to 30 years old
+// child - 2 to 17 years old
+// baby - 0 to 2 monthts old
+function getRandomBirthday(profile: PatientProfile): string {
+  const now = new Date();
+  const randInt = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
+
+  const birth = new Date(now);
+
+  if (profile === 'adultWomen' || profile === 'adultMen') {
+    // pick an age between 18 and 30 years, plus up to 364 extra days for variety
+    const years = randInt(18, 30);
+    const extraDays = randInt(0, 364);
+    birth.setFullYear(birth.getFullYear() - years);
+    birth.setDate(birth.getDate() - extraDays);
+  } else if (profile === 'newborn') {
+    // baby: 0 to ~60 days old
+    const days = randInt(0, 60);
+    birth.setDate(birth.getDate() - days);
+  } else {
+    // pick an age between 2 and 17 years, plus up to 364 extra days for variety
+    const years = randInt(2, 17);
+    const extraDays = randInt(0, 364);
+    birth.setFullYear(birth.getFullYear() - years);
+    birth.setDate(birth.getDate() - extraDays);
+  }
+
+  const y = birth.getFullYear();
+  const m = String(birth.getMonth() + 1).padStart(2, '0');
+  const d = String(birth.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export const generateRandomPatient = async (
+  api: APIRequestContext,
+  profile: PatientProfile,
+  locationUuid?: string,
+): Promise<Patient> => {
+  const identifierRes = await api.post(`idgen/identifiersource/${KGHEmrIdSourceUuid}/identifier`, {
+    data: {},
+  });
+  await expect(identifierRes.ok()).toBeTruthy();
+  const { identifier } = await identifierRes.json();
+
+  const patientInfo = getPatientInfoFromProfile(profile);
+
+  const patientRes = await api.post('patient', {
+    // TODO: This is not configurable right now. It probably should be.
+    data: {
+      identifiers: [
+        {
+          identifier,
+          identifierType: KGHEmrIdTypeUuid,
+          location: locationUuid || process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
+          preferred: true,
+        },
+      ],
+      person: {
+        addresses: [
+          {
+            address1: 'Sesame Street',
+            address2: '',
+            cityVillage: 'Kono',
+            country: 'Sierra Leone',
+            postalCode: '12345',
+            stateProvince: 'Koidu',
+          },
+        ],
+        attributes: [],
+        birthdate: patientInfo.birthdate,
+        birthdateEstimated: false,
+        dead: false,
+        gender: patientInfo.gender,
+        names: [
+          {
+            familyName: patientInfo.familyName,
+            givenName: patientInfo.givenName,
+            middleName: '',
+            preferred: true,
+          },
+        ],
+      },
+    },
+  });
+  await expect(patientRes.ok()).toBeTruthy();
+  return await patientRes.json();
+};
+
+export const getPatient = async (api: APIRequestContext, uuid: string): Promise<Patient> => {
+  const patientRes = await api.get(`patient/${uuid}?v=full`);
+  return await patientRes.json();
+};
+
+export const deletePatient = async (api: APIRequestContext, uuid: string) => {
+  const response = await api.delete(`patient/${uuid}`);
+  await expect(response.ok()).toBeTruthy();
+};
+
+export function getPatientIdentifierStr(patient: Patient) {
+  return patient.identifiers[0].display.split('=')[1].trim();
+}
+
+export function getPatientName(patient: Patient) {
+  return patient.person.display;
+}

--- a/e2e/commands/visit-operations.ts
+++ b/e2e/commands/visit-operations.ts
@@ -1,0 +1,34 @@
+import dayjs from 'dayjs';
+import { type APIRequestContext, expect } from '@playwright/test';
+import { type Visit } from '@openmrs/esm-framework';
+import { KGHVisitType } from '../core';
+
+/**
+ * Mostly taken from openmrs-esm-patient-management
+ */
+
+export const startVisit = async (api: APIRequestContext, patientId: string, locationUuid?: string): Promise<Visit> => {
+  const visitRes = await api.post('visit', {
+    data: {
+      startDatetime: dayjs().format('YYYY-MM-DDTHH:mm:ss.SSSZZ'),
+      patient: patientId,
+      location: locationUuid || process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
+      visitType: KGHVisitType,
+      attributes: [],
+    },
+  });
+
+  await expect(visitRes.ok()).toBeTruthy();
+  return await visitRes.json();
+};
+
+export const endVisit = async (api: APIRequestContext, uuid: string, isWardTest = false) => {
+  await api.post(`visit/${uuid}`, {
+    data: {
+      location: isWardTest ? process.env.E2E_WARD_LOCATION_UUID : process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
+      startDatetime: dayjs().subtract(1, 'D').format('YYYY-MM-DDTHH:mm:ss.SSSZZ'),
+      visitType: KGHVisitType,
+      stopDatetime: dayjs().format('YYYY-MM-DDTHH:mm:ss.SSSZZ'),
+    },
+  });
+};

--- a/e2e/core/constants.ts
+++ b/e2e/core/constants.ts
@@ -1,0 +1,10 @@
+export const KGHLocationsUuids = {
+  'MCOE Triage': 'f85feffc-fe54-4648-aa14-01ed6d30b943',
+  'Labour and Delivery': '11377a5b-6850-11ee-ab8d-0242ac120002',
+  'Antenatal Ward': '11f5c9f9-40b8-46ad-9e7e-59473ce43246',
+};
+
+export const KGHEmrIdSourceUuid = '809b23e3-7162-11eb-8aa6-0242ac110002';
+export const KGHEmrIdTypeUuid = 'c09a1d24-7162-11eb-8aa6-0242ac110002';
+
+export const KGHVisitType = '90973824-1AE9-4E22-B2BB-9CBD56FB3238';

--- a/e2e/core/global-setup.ts
+++ b/e2e/core/global-setup.ts
@@ -1,0 +1,36 @@
+import { request } from '@playwright/test';
+import * as dotenv from 'dotenv';
+
+/**
+ * Mostly taken from openmrs-esm-patient-management
+ */
+
+dotenv.config();
+
+/**
+ * This configuration is to reuse the signed-in state in the tests
+ * by log in only once using the API and then skip the log in step for all the tests.
+ *
+ * https://playwright.dev/docs/auth#reuse-signed-in-state
+ */
+
+async function globalSetup() {
+  const requestContext = await request.newContext();
+  const token = Buffer.from(`${process.env.E2E_USER_ADMIN_USERNAME}:${process.env.E2E_USER_ADMIN_PASSWORD}`).toString(
+    'base64',
+  );
+  await requestContext.post(`${process.env.E2E_BASE_URL}/ws/rest/v1/session`, {
+    data: {
+      sessionLocation: process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
+      locale: 'en',
+    },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${token}`,
+    },
+  });
+  await requestContext.storageState({ path: 'e2e/storageState.json' });
+  await requestContext.dispose();
+}
+
+export default globalSetup;

--- a/e2e/core/index.ts
+++ b/e2e/core/index.ts
@@ -1,0 +1,2 @@
+export * from './test';
+export * from './constants';

--- a/e2e/core/test.ts
+++ b/e2e/core/test.ts
@@ -41,3 +41,17 @@ export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
     { scope: 'test', auto: true },
   ],
 });
+
+// decorator method
+export function step(target: Function, context: ClassMethodDecoratorContext) {
+  return function replacementMethod(...args: any) {
+    const name = this.constructor.name + '.' + (context.name as string);
+    return test.step(
+      name,
+      async () => {
+        return await target.call(this, ...args);
+      },
+      { box: true },
+    );
+  };
+}

--- a/e2e/core/test.ts
+++ b/e2e/core/test.ts
@@ -1,0 +1,43 @@
+import { type APIRequestContext, type Page, test as base } from '@playwright/test';
+import { api } from '../fixtures';
+import { generateRandomPatient, deletePatient, startVisit, endVisit } from '../commands';
+import { type Patient, type Visit } from '@openmrs/esm-framework';
+
+/**
+ * Mostly taken from openmrs-esm-patient-management
+ */
+
+// This file sets up our custom test harness using the custom fixtures.
+// See https://playwright.dev/docs/test-fixtures#creating-a-fixture for details.
+// If a spec intends to use one of the custom fixtures, the special `test` function
+// exported from this file must be used instead of the default `test` function
+// provided by playwright.
+
+export interface CustomTestFixtures {
+  adultWoman: Patient;
+  adultWomanVisit: Visit;
+}
+
+export interface CustomWorkerFixtures {
+  api: APIRequestContext;
+}
+
+export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
+  api: [api, { scope: 'worker' }],
+  adultWoman: [
+    async ({ api }, use) => {
+      const patient = await generateRandomPatient(api, 'adultWomen');
+      await use(patient);
+      await deletePatient(api, patient.uuid);
+    },
+    { scope: 'test', auto: true },
+  ],
+  adultWomanVisit: [
+    async ({ api, adultWoman }, use) => {
+      const visit = await startVisit(api, adultWoman.uuid, '074b2ab0-716a-11eb-8aa6-0242ac110002'); // kgh
+      await use(visit);
+      await endVisit(api, visit.uuid);
+    },
+    { scope: 'test', auto: true },
+  ],
+});

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -1,0 +1,26 @@
+import { type APIRequestContext, type PlaywrightWorkerArgs, type WorkerFixture } from '@playwright/test';
+
+/**
+ * A fixture which initializes an [`APIRequestContext`](https://playwright.dev/docs/api/class-apirequestcontext)
+ * that is bound to the configured OpenMRS API server. The context is automatically authenticated
+ * using the configured admin account.
+ *
+ * Use the request context like this:
+ * ```ts
+ * test('your test', async ({ api }) => {
+ *   const res = await api.get('patient/1234');
+ *   await expect(res.ok()).toBeTruthy();
+ * });
+ * ```
+ */
+export const api: WorkerFixture<APIRequestContext, PlaywrightWorkerArgs> = async ({ playwright }, use) => {
+  const ctx = await playwright.request.newContext({
+    baseURL: `${process.env.E2E_BASE_URL}/ws/rest/v1/`,
+    httpCredentials: {
+      username: process.env.E2E_USER_ADMIN_USERNAME,
+      password: process.env.E2E_USER_ADMIN_PASSWORD,
+    },
+  });
+
+  use(ctx);
+};

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -1,0 +1,1 @@
+export * from './api';

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,0 +1,1 @@
+export * from './ward-page';

--- a/e2e/pages/o2/forms/maternal-admission-form-page.ts
+++ b/e2e/pages/o2/forms/maternal-admission-form-page.ts
@@ -1,0 +1,19 @@
+import { type Page } from '@playwright/test';
+import { type O2VisitPage } from '../visit-page';
+
+type FormFields = {
+  admittedTo: string;
+};
+
+export class MaternalAdmissionFormPage {
+  constructor(readonly o2VisitPage: O2VisitPage) {}
+
+  async fillForm({ admittedTo }: FormFields) {
+    await this.o2VisitPage.page.locator('select[name="w3"]').selectOption(admittedTo);
+  }
+
+  async save() {
+    await this.o2VisitPage.page.getByRole('button', { name: 'Save' }).click();
+    return this.o2VisitPage;
+  }
+}

--- a/e2e/pages/o2/forms/mch-triage-form-page.ts
+++ b/e2e/pages/o2/forms/mch-triage-form-page.ts
@@ -1,0 +1,33 @@
+import { type O2VisitPage } from '../visit-page';
+import { test } from '../../../core';
+
+type LocationName = string;
+
+type FormFields = {
+  provider?: string;
+  disposition: { admitToWard: LocationName } | 'discharge';
+};
+
+export class MCHTriageFormPage {
+  constructor(readonly o2VisitPage: O2VisitPage) {}
+
+  async fillForm({ provider = 'Account, Testing', disposition }: FormFields) {
+    await test.step(`Fill the MCH Triage form with provider ${provider} and disposition ${disposition}`, async () => {
+      await this.o2VisitPage.page.locator('select[name="w1"]').selectOption(provider);
+      if (disposition === 'discharge') {
+        await this.o2VisitPage.page.locator('select[name="w124"]').selectOption('Discharge');
+        return this;
+      } else {
+        await this.o2VisitPage.page.locator('select[name="w124"]').selectOption('Admission');
+        await this.o2VisitPage.page.locator('select[name="w126"]').selectOption(disposition.admitToWard);
+      }
+    });
+  }
+
+  async save() {
+    await test.step(`Save the MCH Triage form`, async () => {
+      await this.o2VisitPage.page.getByRole('button', { name: 'Save' }).click();
+      return this.o2VisitPage;
+    });
+  }
+}

--- a/e2e/pages/o2/forms/mch-triage-form-page.ts
+++ b/e2e/pages/o2/forms/mch-triage-form-page.ts
@@ -13,9 +13,10 @@ export class MCHTriageFormPage {
   constructor(readonly o2VisitPage: O2VisitPage) {}
 
   @step
-  async fillForm({ provider = 'Account, Testing', disposition }: FormFields) {
+  async fillForm({ provider, disposition }: FormFields) {
+    const providerName = provider ?? process.env.E2E_DEFAULT_PROVIDER_NAME;
     await test.step(`Fill the MCH Triage form with provider ${provider} and disposition ${disposition}`, async () => {
-      await this.o2VisitPage.page.locator('select[name="w1"]').selectOption(provider);
+      await this.o2VisitPage.page.locator('select[name="w1"]').selectOption(providerName);
       if (disposition === 'discharge') {
         await this.o2VisitPage.page.locator('select[name="w124"]').selectOption('Discharge');
         return this;

--- a/e2e/pages/o2/forms/mch-triage-form-page.ts
+++ b/e2e/pages/o2/forms/mch-triage-form-page.ts
@@ -1,5 +1,6 @@
+import { expect } from '@playwright/test';
 import { type O2VisitPage } from '../visit-page';
-import { test } from '../../../core';
+import { step, test } from '../../../core';
 
 type LocationName = string;
 
@@ -11,6 +12,7 @@ type FormFields = {
 export class MCHTriageFormPage {
   constructor(readonly o2VisitPage: O2VisitPage) {}
 
+  @step
   async fillForm({ provider = 'Account, Testing', disposition }: FormFields) {
     await test.step(`Fill the MCH Triage form with provider ${provider} and disposition ${disposition}`, async () => {
       await this.o2VisitPage.page.locator('select[name="w1"]').selectOption(provider);
@@ -24,10 +26,18 @@ export class MCHTriageFormPage {
     });
   }
 
+  @step
   async save() {
     await test.step(`Save the MCH Triage form`, async () => {
       await this.o2VisitPage.page.getByRole('button', { name: 'Save' }).click();
       return this.o2VisitPage;
+    });
+  }
+
+  @step
+  async expectSuccessToast(patientName: string) {
+    await test.step('Then I should see success toast', async () => {
+      await expect(this.o2VisitPage.page.getByText('Entered MCOE Triage for ' + patientName)).toBeVisible();
     });
   }
 }

--- a/e2e/pages/o2/visit-page.ts
+++ b/e2e/pages/o2/visit-page.ts
@@ -1,0 +1,39 @@
+import { type Page } from '@playwright/test';
+import { test } from '../../core';
+import { type Patient, type Visit } from '@openmrs/esm-framework';
+import { MaternalAdmissionFormPage } from './forms/maternal-admission-form-page';
+import { MCHTriageFormPage } from './forms/mch-triage-form-page';
+
+export class O2VisitPage {
+  private constructor(readonly page: Page) {}
+
+  readonly formsTable = () => this.page.getByRole('table', { name: /forms/i });
+
+  static async open(page: Page, patient: Patient, visit: Visit) {
+    return test.step(`Open the visit page for patient ${patient.uuid} and visit ${visit.uuid}`, async () => {
+      const visitPage = new O2VisitPage(page);
+      await visitPage.page.goto(
+        `${process.env.E2E_BASE_URL}/pihcore/visit/visit.page?patient=${patient.uuid}&visit=${visit.uuid}`,
+      );
+      return visitPage;
+    });
+  }
+
+  private async openForm(formName: string) {
+    await this.page.locator('#visit-app').getByText(formName).click();
+  }
+
+  async openMaternalAdmissionForm() {
+    await test.step(`Open the Maternal Admission form`, async () => {
+      await this.openForm('Maternal Admission');
+    });
+    return new MaternalAdmissionFormPage(this);
+  }
+
+  async openMCHTriageForm() {
+    await test.step(`Open the MCH Triage form`, async () => {
+      await this.openForm('Triage');
+    });
+    return new MCHTriageFormPage(this);
+  }
+}

--- a/e2e/pages/o2/visit-page.ts
+++ b/e2e/pages/o2/visit-page.ts
@@ -1,5 +1,5 @@
 import { type Page } from '@playwright/test';
-import { test } from '../../core';
+import { step, test } from '../../core';
 import { type Patient, type Visit } from '@openmrs/esm-framework';
 import { MaternalAdmissionFormPage } from './forms/maternal-admission-form-page';
 import { MCHTriageFormPage } from './forms/mch-triage-form-page';
@@ -9,6 +9,7 @@ export class O2VisitPage {
 
   readonly formsTable = () => this.page.getByRole('table', { name: /forms/i });
 
+  @step
   static async open(page: Page, patient: Patient, visit: Visit) {
     return test.step(`Open the visit page for patient ${patient.uuid} and visit ${visit.uuid}`, async () => {
       const visitPage = new O2VisitPage(page);
@@ -19,10 +20,12 @@ export class O2VisitPage {
     });
   }
 
+  @step
   private async openForm(formName: string) {
     await this.page.locator('#visit-app').getByText(formName).click();
   }
 
+  @step
   async openMaternalAdmissionForm() {
     await test.step(`Open the Maternal Admission form`, async () => {
       await this.openForm('Maternal Admission');
@@ -30,6 +33,7 @@ export class O2VisitPage {
     return new MaternalAdmissionFormPage(this);
   }
 
+  @step
   async openMCHTriageForm() {
     await test.step(`Open the MCH Triage form`, async () => {
       await this.openForm('Triage');

--- a/e2e/pages/ward-page.ts
+++ b/e2e/pages/ward-page.ts
@@ -1,5 +1,5 @@
 import { expect, type Page } from '@playwright/test';
-import { test } from '../core';
+import { step, test } from '../core';
 import { type Patient } from '@openmrs/esm-framework';
 import { getPatientIdentifierStr, getPatientName } from '../commands';
 
@@ -15,31 +15,68 @@ export class WardPage {
   readonly clinicalNotesField = () => this.page.getByRole('textbox', { name: /clinical notes/i });
   readonly wardAdmissionNoteField = () => this.page.getByRole('textbox', { name: /write your notes/i });
   readonly cancelAdmissionRequestHeading = () => this.page.getByText('Cancel admission request');
-  readonly transferButton = () => this.page.getByRole('button', { name: 'Transfers' });
+  readonly transfersButton = () => this.page.getByRole('button', { name: 'Transfers' });
   readonly swapButton = () => this.page.getByRole('tab', { name: 'Bed swap' });
+  readonly addPatientToWardButton = () => this.page.getByRole('button', { name: 'Add patient to ward' });
+  readonly patientSearchBar = () => this.page.getByTestId('patientSearchBar');
 
+  patientCard(patientName: string) {
+    return this.page.locator(`[class*="wardPatientCard"]:has-text("${patientName}")`).first();
+  }
+
+  patientSearchResult(patientName: string) {
+    return this.page.getByRole('button', { name: patientName });
+  }
+
+  manageAdmissionRequests() {
+    return this.manageAdmissionRequestsButton();
+  }
+
+  patientNotesButton() {
+    return this.page.getByRole('button', { name: 'Patient Note' });
+  }
+
+  cancelAdmissionButton(patientName: string) {
+    return this.page
+      .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
+      .filter({ hasText: 'Cancel' })
+      .first();
+  }
+
+  admitElsewhereButton(patientName: string) {
+    return this.page
+      .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
+      .filter({ hasText: 'Admit elsewhere' })
+      .first();
+  }
+
+  transferElsewhereButton(patientName: string) {
+    return this.page
+      .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
+      .filter({ hasText: 'Transfer elsewhere' })
+      .first();
+  }
+
+  admitPatientButton(patientName: string) {
+    return this.page
+      .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
+      .filter({ hasText: 'Admit patient' })
+      .first();
+  }
+
+  transferPatientButton(patientName: string) {
+    return this.page
+      .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
+      .filter({ hasText: 'Transfer patient' })
+      .first();
+  }
+
+  @step
   static async open(page: Page) {
     return test.step('When I navigate to the ward page', async () => {
       const wardPage = new WardPage(page);
       wardPage.page.goto('/openmrs/spa/home/ward');
       return wardPage;
-    });
-  }
-
-  async clickPatientCard(patientName: string) {
-    // Wait for patient to be loaded - use first() to avoid strict mode violation
-    await this.page
-      .locator(`[class*="wardPatientCard"]:has-text("${patientName}")`)
-      .first()
-      .waitFor({ state: 'visible' });
-
-    // Click the patient card directly
-    await this.page.locator(`[class*="wardPatientCard"]:has-text("${patientName}")`).first().click({ force: true });
-  }
-
-  async clickManageAdmissionRequests() {
-    await test.step('When I click the "Manage" button to view admission requests', async () => {
-      await this.manageAdmissionRequestsButton().click();
     });
   }
 
@@ -53,50 +90,8 @@ export class WardPage {
       .waitFor({ state: 'visible', timeout: 5000 });
   }
 
-  async clickPatientNotesButton() {
-    await this.page.getByRole('button', { name: 'Patient Note' }).click();
-  }
-
-  async clickCancelAdmissionButton(patientName: string) {
-    return test.step(`When I click the "Cancel" button for patient ${patientName}`, async () => {
-      return this.page
-        .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
-        .filter({ hasText: 'Cancel' })
-        .first()
-        .click();
-    });
-  }
-
-  async clickAdmitElsewhereButton(patientName: string) {
-    return test.step(`When I click the "Admit elsewhere" button for patient ${patientName}`, async () => {
-      return this.page
-        .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
-        .filter({ hasText: 'Admit elsewhere' })
-        .first()
-        .click();
-    });
-  }
-
-  async clickTransferElsewhereButton(patientName: string) {
-    return test.step(`When I click the "Transfer elsewhere" button for patient ${patientName}`, async () => {
-      return this.page
-        .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
-        .filter({ hasText: 'Transfer elsewhere' })
-        .first()
-        .click();
-    });
-  }
-
   async fillWardAdmissionNote(note: string) {
     await this.wardAdmissionNoteField().fill(note);
-  }
-
-  async clickSaveButton() {
-    await this.saveButton().click();
-  }
-
-  async expectAdmissionRequestCancelled() {
-    await this.page.getByText(/admission request cancelled/i).waitFor({ state: 'visible' });
   }
 
   async waitForPatientInWardView(patientName: string) {
@@ -106,38 +101,33 @@ export class WardPage {
       .waitFor({ state: 'visible' });
   }
 
-  async clickAdmitPatientButton(patientName: string) {
-    return test.step(`When I click the "Admit patient" button for patient ${patientName}`, async () => {
-      return this.page
-        .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
-        .filter({ hasText: 'Admit patient' })
-        .first()
-        .click();
-    });
-  }
-
-  async clickTransferPatientButton(patientName: string) {
-    return test.step(`When I click the "Transfer patient" button for patient ${patientName}`, async () => {
-      return this.page
-        .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
-        .filter({ hasText: 'Transfer patient' })
-        .first()
-        .click();
-    });
-  }
-
+  @step
   async selectBed(bedNumber: string) {
     return test.step(`When I select bed ${bedNumber} for the patient admission`, async () => {
       await this.page.getByText(new RegExp(`^${bedNumber} · `)).click();
     });
   }
 
+  @step
+  async selectLocation(locationName: string) {
+    await this.page.locator('#omrs-workspaces-container').getByText(locationName).click();
+  }
+
+  @step
+  async clickSaveButton() {
+    return test.step('When I click the "Save" button', async () => {
+      await this.page.getByRole('button', { name: 'Save', exact: true }).click();
+    });
+  }
+
+  @step
   async clickAdmitButton() {
     return test.step('When I click the "Admit" button to confirm patient admission', async () => {
       await this.page.getByRole('button', { name: 'Admit', exact: true }).click();
     });
   }
 
+  @step
   async expectAdmissionSuccessNotification(patientName: string, bedNumber: string) {
     return test.step(`Then I should see a success message confirming ${patientName} was admitted to bed ${bedNumber}`, async () => {
       await expect(this.page.getByText('Patient admitted successfully')).toBeVisible();
@@ -149,9 +139,24 @@ export class WardPage {
     });
   }
 
+  @step
   async expectPatientAdmittedToWard(patient: Patient) {
     return test.step(`Then I should see the patient ${getPatientName(patient)} admitted to the ward`, async () => {
       await expect(this.page.getByText(getPatientIdentifierStr(patient))).toBeVisible();
+    });
+  }
+
+  @step
+  async expectTransferRequestSubmitted() {
+    return await test.step('Then I should see the transfer request submitted successfully', async () => {
+      await expect(this.page.getByText('Patient transfer request created')).toBeVisible();
+    });
+  }
+
+  @step
+  async expectAdmissionRequestCancelled() {
+    return await test.step('Then I should see success toast for cancelled admission request', async () => {
+      await expect(this.page.getByText('admission request cancelled')).toBeVisible();
     });
   }
 }

--- a/e2e/pages/ward-page.ts
+++ b/e2e/pages/ward-page.ts
@@ -104,6 +104,9 @@ export class WardPage {
   @step
   async selectBed(bedNumber: string) {
     return test.step(`When I select bed ${bedNumber} for the patient admission`, async () => {
+      if (await this.page.getByRole('combobox', { name: 'Choose an option' }).isVisible()) {
+        await this.page.getByRole('combobox', { name: 'Choose an option' }).click();
+      }
       await this.page.getByText(new RegExp(`^${bedNumber} · `)).click();
     });
   }

--- a/e2e/pages/ward-page.ts
+++ b/e2e/pages/ward-page.ts
@@ -1,0 +1,157 @@
+import { expect, type Page } from '@playwright/test';
+import { test } from '../core';
+import { type Patient } from '@openmrs/esm-framework';
+import { getPatientIdentifierStr, getPatientName } from '../commands';
+
+/**
+ * Mostly taken from openmrs-esm-patient-management
+ */
+export class WardPage {
+  private constructor(readonly page: Page) {}
+
+  readonly manageAdmissionRequestsButton = () => this.page.getByRole('button', { name: 'Manage' });
+  readonly cancelButton = () => this.page.getByRole('button', { name: 'Cancel' });
+  readonly saveButton = () => this.page.getByRole('button', { name: 'Save' });
+  readonly clinicalNotesField = () => this.page.getByRole('textbox', { name: /clinical notes/i });
+  readonly wardAdmissionNoteField = () => this.page.getByRole('textbox', { name: /write your notes/i });
+  readonly cancelAdmissionRequestHeading = () => this.page.getByText('Cancel admission request');
+  readonly transferButton = () => this.page.getByRole('button', { name: 'Transfers' });
+  readonly swapButton = () => this.page.getByRole('tab', { name: 'Bed swap' });
+
+  static async open(page: Page) {
+    return test.step('When I navigate to the ward page', async () => {
+      const wardPage = new WardPage(page);
+      wardPage.page.goto('/openmrs/spa/home/ward');
+      return wardPage;
+    });
+  }
+
+  async clickPatientCard(patientName: string) {
+    // Wait for patient to be loaded - use first() to avoid strict mode violation
+    await this.page
+      .locator(`[class*="wardPatientCard"]:has-text("${patientName}")`)
+      .first()
+      .waitFor({ state: 'visible' });
+
+    // Click the patient card directly
+    await this.page.locator(`[class*="wardPatientCard"]:has-text("${patientName}")`).first().click({ force: true });
+  }
+
+  async clickManageAdmissionRequests() {
+    await test.step('When I click the "Manage" button to view admission requests', async () => {
+      await this.manageAdmissionRequestsButton().click();
+    });
+  }
+
+  async waitForAdmissionRequest(patientName: string) {
+    // Wait for the admission request to appear in the list
+    // Note: API polling in test setup ensures data is available, so shorter timeout is sufficient
+    await this.page
+      .locator('[class*="admissionRequestCard"]')
+      .filter({ hasText: patientName })
+      .first()
+      .waitFor({ state: 'visible', timeout: 5000 });
+  }
+
+  async clickPatientNotesButton() {
+    await this.page.getByRole('button', { name: 'Patient Note' }).click();
+  }
+
+  async clickCancelAdmissionButton(patientName: string) {
+    return test.step(`When I click the "Cancel" button for patient ${patientName}`, async () => {
+      return this.page
+        .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
+        .filter({ hasText: 'Cancel' })
+        .first()
+        .click();
+    });
+  }
+
+  async clickAdmitElsewhereButton(patientName: string) {
+    return test.step(`When I click the "Admit elsewhere" button for patient ${patientName}`, async () => {
+      return this.page
+        .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
+        .filter({ hasText: 'Admit elsewhere' })
+        .first()
+        .click();
+    });
+  }
+
+  async clickTransferElsewhereButton(patientName: string) {
+    return test.step(`When I click the "Transfer elsewhere" button for patient ${patientName}`, async () => {
+      return this.page
+        .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
+        .filter({ hasText: 'Transfer elsewhere' })
+        .first()
+        .click();
+    });
+  }
+
+  async fillWardAdmissionNote(note: string) {
+    await this.wardAdmissionNoteField().fill(note);
+  }
+
+  async clickSaveButton() {
+    await this.saveButton().click();
+  }
+
+  async expectAdmissionRequestCancelled() {
+    await this.page.getByText(/admission request cancelled/i).waitFor({ state: 'visible' });
+  }
+
+  async waitForPatientInWardView(patientName: string) {
+    await this.page
+      .locator(`[class*="wardPatientCard"]:has-text("${patientName}")`)
+      .first()
+      .waitFor({ state: 'visible' });
+  }
+
+  async clickAdmitPatientButton(patientName: string) {
+    return test.step(`When I click the "Admit patient" button for patient ${patientName}`, async () => {
+      return this.page
+        .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
+        .filter({ hasText: 'Admit patient' })
+        .first()
+        .click();
+    });
+  }
+
+  async clickTransferPatientButton(patientName: string) {
+    return test.step(`When I click the "Transfer patient" button for patient ${patientName}`, async () => {
+      return this.page
+        .locator(`[class*="admissionRequestCard"]:has-text("${patientName}") button`)
+        .filter({ hasText: 'Transfer patient' })
+        .first()
+        .click();
+    });
+  }
+
+  async selectBed(bedNumber: string) {
+    return test.step(`When I select bed ${bedNumber} for the patient admission`, async () => {
+      await this.page.getByText(new RegExp(`^${bedNumber} · `)).click();
+    });
+  }
+
+  async clickAdmitButton() {
+    return test.step('When I click the "Admit" button to confirm patient admission', async () => {
+      await this.page.getByRole('button', { name: 'Admit', exact: true }).click();
+    });
+  }
+
+  async expectAdmissionSuccessNotification(patientName: string, bedNumber: string) {
+    return test.step(`Then I should see a success message confirming ${patientName} was admitted to bed ${bedNumber}`, async () => {
+      await expect(this.page.getByText('Patient admitted successfully')).toBeVisible();
+      await expect(
+        this.page.getByText(
+          new RegExp(`${patientName}\\s+has been successfully admitted and assigned to bed ${bedNumber}`, 'i'),
+        ),
+      ).toBeVisible();
+    });
+  }
+
+  async expectPatientAdmittedToWard(patient: Patient) {
+    return test.step(`Then I should see the patient ${getPatientName(patient)} admitted to the ward`, async () => {
+      await expect(this.page.getByText(getPatientIdentifierStr(patient))).toBeVisible();
+    });
+  }
+}

--- a/e2e/specs/ward/ward-admission.spec.ts
+++ b/e2e/specs/ward/ward-admission.spec.ts
@@ -1,0 +1,160 @@
+import { expect } from '@playwright/test';
+import { changeLocation, getPatientIdentifierStr, getPatientName } from '../../commands';
+import { KGHLocationsUuids, test } from '../../core';
+import { WardPage } from '../../pages';
+import { O2VisitPage } from '../../pages/o2/visit-page';
+
+test.describe('Ward App', () => {
+  test.beforeEach(async ({ api }) => {
+    await changeLocation(api, KGHLocationsUuids['MCOE Triage']);
+  });
+
+  test('Admit a patient to a ward from the admission requests list, then transfer to another location', async ({
+    page,
+    api,
+    adultWoman,
+    adultWomanVisit,
+  }) => {
+    const patientName = getPatientName(adultWoman);
+
+    const o2VisitPage: O2VisitPage = await O2VisitPage.open(page, adultWoman, adultWomanVisit);
+    const mchTriageFormPage = await o2VisitPage.openMCHTriageForm();
+    await mchTriageFormPage.fillForm({ disposition: { admitToWard: 'Labour and Delivery' } });
+    await mchTriageFormPage.save();
+
+    await test.step('Then I should see success toast', async () => {
+      await expect(page.getByText('Entered MCOE Triage for ' + adultWoman.person.display)).toBeVisible();
+    });
+
+    await changeLocation(api, KGHLocationsUuids['Labour and Delivery']);
+    const wardPage = await WardPage.open(page);
+    await wardPage.clickManageAdmissionRequests();
+
+    await wardPage.clickAdmitPatientButton(patientName);
+
+    await test.step('When I select bed 1 and click the "Admit" button', async () => {
+      await page.getByText(/^1 · /).click();
+      await page.getByRole('button', { name: 'Admit', exact: true }).click();
+    });
+
+    await wardPage.expectAdmissionSuccessNotification(patientName, '1');
+    await wardPage.expectPatientAdmittedToWard(adultWoman);
+
+    await wardPage.clickPatientCard(patientName);
+    await page.getByRole('button', { name: 'Transfers' }).click();
+    await page.locator('#omrs-workspaces-container').getByText('Antenatal Ward').click();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await test.step('Then I should see the transfer request submitted successfully', async () => {
+      await expect(page.getByText('Patient transfer request created')).toBeVisible();
+    });
+
+    await changeLocation(api, KGHLocationsUuids['Antenatal Ward']);
+    const antenatalWardPage = await WardPage.open(page);
+    await antenatalWardPage.clickManageAdmissionRequests();
+    await antenatalWardPage.clickAdmitPatientButton(patientName);
+
+    await antenatalWardPage.selectBed('1');
+    await antenatalWardPage.clickAdmitButton();
+    await antenatalWardPage.expectAdmissionSuccessNotification(patientName, '1');
+
+    await wardPage.expectPatientAdmittedToWard(adultWoman);
+  });
+
+  test('Cancel a patient admission request from the ward admission requests list', async ({
+    page,
+    api,
+    adultWoman,
+    adultWomanVisit,
+  }) => {
+    const patientName = getPatientName(adultWoman);
+
+    const o2VisitPage: O2VisitPage = await O2VisitPage.open(page, adultWoman, adultWomanVisit);
+    const mchTriageFormPage = await o2VisitPage.openMCHTriageForm();
+    await mchTriageFormPage.fillForm({ disposition: { admitToWard: 'Labour and Delivery' } });
+    await mchTriageFormPage.save();
+
+    await test.step('Then I should see success toast', async () => {
+      await expect(page.getByText('Entered MCOE Triage for ' + adultWoman.person.display)).toBeVisible();
+    });
+
+    await changeLocation(api, KGHLocationsUuids['Labour and Delivery']);
+    const wardPage = await WardPage.open(page);
+    await wardPage.clickManageAdmissionRequests();
+
+    await wardPage.clickCancelAdmissionButton(patientName);
+
+    await test.step('When I fill the admission cancellation note and click the "Save" button', async () => {
+      await wardPage.clinicalNotesField().fill('Patient does not require admission at this time');
+      await wardPage.clickSaveButton();
+    });
+
+    await test.step('Then I should see success toast for cancelled admission request', async () => {
+      await expect(page.getByText('admission request cancelled')).toBeVisible();
+    });
+  });
+
+  test('Have a patient admit elsewhere from the ward admission requests list', async ({
+    page,
+    api,
+    adultWoman,
+    adultWomanVisit,
+  }) => {
+    const patientName = getPatientName(adultWoman);
+    const patientIdentifier = getPatientIdentifierStr(adultWoman);
+
+    const o2VisitPage: O2VisitPage = await O2VisitPage.open(page, adultWoman, adultWomanVisit);
+    const mchTriageFormPage = await o2VisitPage.openMCHTriageForm();
+    await mchTriageFormPage.fillForm({ disposition: { admitToWard: 'Labour and Delivery' } });
+    await mchTriageFormPage.save();
+
+    await test.step('Then I should see success toast', async () => {
+      await expect(page.getByText('Entered MCOE Triage for ' + adultWoman.person.display)).toBeVisible();
+    });
+
+    await changeLocation(api, KGHLocationsUuids['Labour and Delivery']);
+    const labourAndDeliveryWardPage = await WardPage.open(page);
+    await labourAndDeliveryWardPage.clickManageAdmissionRequests();
+
+    await labourAndDeliveryWardPage.clickAdmitElsewhereButton(patientName);
+
+    await page.locator('#omrs-workspaces-container').getByText('Antenatal Ward').click();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await test.step('Then I should see the admission request submitted successfully', async () => {
+      await expect(page.getByText('Patient admission request created')).toBeVisible();
+    });
+
+    await changeLocation(api, KGHLocationsUuids['Antenatal Ward']);
+    const antenatalWardPage = await WardPage.open(page);
+    await antenatalWardPage.clickManageAdmissionRequests();
+    await antenatalWardPage.clickAdmitPatientButton(patientName);
+
+    await antenatalWardPage.selectBed('1');
+    await antenatalWardPage.clickAdmitButton();
+    await antenatalWardPage.expectAdmissionSuccessNotification(patientName, '1');
+
+    await antenatalWardPage.expectPatientAdmittedToWard(adultWoman);
+  });
+
+  test('Search for a patient to admit to ward', async ({ page, api, adultWoman, adultWomanVisit }) => {
+    const patientName = getPatientName(adultWoman);
+    const patientIdentifier = getPatientIdentifierStr(adultWoman);
+
+    await changeLocation(api, KGHLocationsUuids['Labour and Delivery']);
+    const wardPage = await WardPage.open(page);
+    await wardPage.clickManageAdmissionRequests();
+
+    await page.getByRole('button', { name: 'Add patient to ward' }).click();
+    await page.getByTestId('patientSearchBar').click();
+    await page.getByTestId('patientSearchBar').fill(patientIdentifier);
+    await page.getByRole('button', { name: patientName }).click();
+    await page.locator('#create-admission-encounter-workspace').getByRole('button', { name: 'admit patient' }).click();
+
+    await wardPage.selectBed('1');
+    await wardPage.clickAdmitButton();
+    await wardPage.expectAdmissionSuccessNotification(patientName, '1');
+
+    await wardPage.expectPatientAdmittedToWard(adultWoman);
+  });
+});

--- a/e2e/specs/ward/ward-admission.spec.ts
+++ b/e2e/specs/ward/ward-admission.spec.ts
@@ -1,4 +1,3 @@
-import { expect } from '@playwright/test';
 import { changeLocation, getPatientIdentifierStr, getPatientName } from '../../commands';
 import { KGHLocationsUuids, test } from '../../core';
 import { WardPage } from '../../pages';
@@ -45,7 +44,7 @@ test.describe('Ward App', () => {
     await changeLocation(api, KGHLocationsUuids['Antenatal Ward']);
     const antenatalWardPage = await WardPage.open(page);
     await antenatalWardPage.manageAdmissionRequests().click();
-    await antenatalWardPage.admitPatientButton(patientName).click();
+    await antenatalWardPage.transferPatientButton(patientName).click();
 
     await antenatalWardPage.selectBed(bedNumber);
     await antenatalWardPage.clickAdmitButton();
@@ -108,7 +107,7 @@ test.describe('Ward App', () => {
     await changeLocation(api, KGHLocationsUuids['Antenatal Ward']);
     const antenatalWardPage = await WardPage.open(page);
     await antenatalWardPage.manageAdmissionRequests().click();
-    await antenatalWardPage.admitPatientButton(patientName).click();
+    await antenatalWardPage.transferPatientButton(patientName).click();
 
     const bedNumber = '1';
     await antenatalWardPage.selectBed(bedNumber);

--- a/e2e/specs/ward/ward-admission.spec.ts
+++ b/e2e/specs/ward/ward-admission.spec.ts
@@ -21,42 +21,35 @@ test.describe('Ward App', () => {
     const mchTriageFormPage = await o2VisitPage.openMCHTriageForm();
     await mchTriageFormPage.fillForm({ disposition: { admitToWard: 'Labour and Delivery' } });
     await mchTriageFormPage.save();
-
-    await test.step('Then I should see success toast', async () => {
-      await expect(page.getByText('Entered MCOE Triage for ' + adultWoman.person.display)).toBeVisible();
-    });
+    await mchTriageFormPage.expectSuccessToast(patientName);
 
     await changeLocation(api, KGHLocationsUuids['Labour and Delivery']);
     const wardPage = await WardPage.open(page);
-    await wardPage.clickManageAdmissionRequests();
+    await wardPage.manageAdmissionRequests().click();
 
-    await wardPage.clickAdmitPatientButton(patientName);
+    await wardPage.admitPatientButton(patientName).click();
 
-    await test.step('When I select bed 1 and click the "Admit" button', async () => {
-      await page.getByText(/^1 · /).click();
-      await page.getByRole('button', { name: 'Admit', exact: true }).click();
-    });
+    const bedNumber = '1';
+    await wardPage.selectBed(bedNumber);
+    await wardPage.clickAdmitButton();
 
-    await wardPage.expectAdmissionSuccessNotification(patientName, '1');
+    await wardPage.expectAdmissionSuccessNotification(patientName, bedNumber);
     await wardPage.expectPatientAdmittedToWard(adultWoman);
 
-    await wardPage.clickPatientCard(patientName);
-    await page.getByRole('button', { name: 'Transfers' }).click();
-    await page.locator('#omrs-workspaces-container').getByText('Antenatal Ward').click();
-    await page.getByRole('button', { name: 'Save' }).click();
-
-    await test.step('Then I should see the transfer request submitted successfully', async () => {
-      await expect(page.getByText('Patient transfer request created')).toBeVisible();
-    });
+    await wardPage.patientCard(patientName).click();
+    await wardPage.transfersButton().click();
+    await wardPage.selectLocation('Antenatal Ward');
+    await wardPage.clickSaveButton();
+    await wardPage.expectTransferRequestSubmitted();
 
     await changeLocation(api, KGHLocationsUuids['Antenatal Ward']);
     const antenatalWardPage = await WardPage.open(page);
-    await antenatalWardPage.clickManageAdmissionRequests();
-    await antenatalWardPage.clickAdmitPatientButton(patientName);
+    await antenatalWardPage.manageAdmissionRequests().click();
+    await antenatalWardPage.admitPatientButton(patientName).click();
 
-    await antenatalWardPage.selectBed('1');
+    await antenatalWardPage.selectBed(bedNumber);
     await antenatalWardPage.clickAdmitButton();
-    await antenatalWardPage.expectAdmissionSuccessNotification(patientName, '1');
+    await antenatalWardPage.expectAdmissionSuccessNotification(patientName, bedNumber);
 
     await wardPage.expectPatientAdmittedToWard(adultWoman);
   });
@@ -73,25 +66,18 @@ test.describe('Ward App', () => {
     const mchTriageFormPage = await o2VisitPage.openMCHTriageForm();
     await mchTriageFormPage.fillForm({ disposition: { admitToWard: 'Labour and Delivery' } });
     await mchTriageFormPage.save();
-
-    await test.step('Then I should see success toast', async () => {
-      await expect(page.getByText('Entered MCOE Triage for ' + adultWoman.person.display)).toBeVisible();
-    });
+    await mchTriageFormPage.expectSuccessToast(patientName);
 
     await changeLocation(api, KGHLocationsUuids['Labour and Delivery']);
     const wardPage = await WardPage.open(page);
-    await wardPage.clickManageAdmissionRequests();
+    await wardPage.manageAdmissionRequests().click();
 
-    await wardPage.clickCancelAdmissionButton(patientName);
+    await wardPage.cancelAdmissionButton(patientName).click();
 
-    await test.step('When I fill the admission cancellation note and click the "Save" button', async () => {
-      await wardPage.clinicalNotesField().fill('Patient does not require admission at this time');
-      await wardPage.clickSaveButton();
-    });
+    await wardPage.clinicalNotesField().fill('Patient does not require admission at this time');
+    await wardPage.clickSaveButton();
 
-    await test.step('Then I should see success toast for cancelled admission request', async () => {
-      await expect(page.getByText('admission request cancelled')).toBeVisible();
-    });
+    await wardPage.expectAdmissionRequestCancelled();
   });
 
   test('Have a patient admit elsewhere from the ward admission requests list', async ({
@@ -107,32 +93,27 @@ test.describe('Ward App', () => {
     const mchTriageFormPage = await o2VisitPage.openMCHTriageForm();
     await mchTriageFormPage.fillForm({ disposition: { admitToWard: 'Labour and Delivery' } });
     await mchTriageFormPage.save();
-
-    await test.step('Then I should see success toast', async () => {
-      await expect(page.getByText('Entered MCOE Triage for ' + adultWoman.person.display)).toBeVisible();
-    });
+    await mchTriageFormPage.expectSuccessToast(patientName);
 
     await changeLocation(api, KGHLocationsUuids['Labour and Delivery']);
     const labourAndDeliveryWardPage = await WardPage.open(page);
-    await labourAndDeliveryWardPage.clickManageAdmissionRequests();
+    await labourAndDeliveryWardPage.manageAdmissionRequests().click();
 
-    await labourAndDeliveryWardPage.clickAdmitElsewhereButton(patientName);
+    await labourAndDeliveryWardPage.admitElsewhereButton(patientName).click();
 
-    await page.locator('#omrs-workspaces-container').getByText('Antenatal Ward').click();
-    await page.getByRole('button', { name: 'Save' }).click();
-
-    await test.step('Then I should see the admission request submitted successfully', async () => {
-      await expect(page.getByText('Patient admission request created')).toBeVisible();
-    });
+    await labourAndDeliveryWardPage.selectLocation('Antenatal Ward');
+    await labourAndDeliveryWardPage.clickSaveButton();
+    await labourAndDeliveryWardPage.expectTransferRequestSubmitted();
 
     await changeLocation(api, KGHLocationsUuids['Antenatal Ward']);
     const antenatalWardPage = await WardPage.open(page);
-    await antenatalWardPage.clickManageAdmissionRequests();
-    await antenatalWardPage.clickAdmitPatientButton(patientName);
+    await antenatalWardPage.manageAdmissionRequests().click();
+    await antenatalWardPage.admitPatientButton(patientName).click();
 
-    await antenatalWardPage.selectBed('1');
+    const bedNumber = '1';
+    await antenatalWardPage.selectBed(bedNumber);
     await antenatalWardPage.clickAdmitButton();
-    await antenatalWardPage.expectAdmissionSuccessNotification(patientName, '1');
+    await antenatalWardPage.expectAdmissionSuccessNotification(patientName, bedNumber);
 
     await antenatalWardPage.expectPatientAdmittedToWard(adultWoman);
   });
@@ -143,17 +124,19 @@ test.describe('Ward App', () => {
 
     await changeLocation(api, KGHLocationsUuids['Labour and Delivery']);
     const wardPage = await WardPage.open(page);
-    await wardPage.clickManageAdmissionRequests();
+    await wardPage.manageAdmissionRequests().click();
 
-    await page.getByRole('button', { name: 'Add patient to ward' }).click();
-    await page.getByTestId('patientSearchBar').click();
-    await page.getByTestId('patientSearchBar').fill(patientIdentifier);
-    await page.getByRole('button', { name: patientName }).click();
+    await wardPage.addPatientToWardButton().click();
+    await wardPage.patientSearchBar().click();
+    await wardPage.patientSearchBar().fill(patientIdentifier);
+    await wardPage.patientSearchResult(patientName).click();
+    // TODO: update this after the html id is checked in for the ward app
     await page.locator('#create-admission-encounter-workspace').getByRole('button', { name: 'admit patient' }).click();
 
-    await wardPage.selectBed('1');
+    const bedNumber = '1';
+    await wardPage.selectBed(bedNumber);
     await wardPage.clickAdmitButton();
-    await wardPage.expectAdmissionSuccessNotification(patientName, '1');
+    await wardPage.expectAdmissionSuccessNotification(patientName, bedNumber);
 
     await wardPage.expectPatientAdmittedToWard(adultWoman);
   });

--- a/e2e/support/bamboo/docker-compose.yml
+++ b/e2e/support/bamboo/docker-compose.yml
@@ -1,0 +1,56 @@
+# This docker compose file is used to create a dockerized environment when running E2E tests on Bamboo.
+version: "3.7"
+
+services:
+  playwright:
+    build:
+      context: .
+      dockerfile: playwright.Dockerfile
+      args:
+        USER_ID: ${USER_ID}
+        GROUP_ID: ${GROUP_ID}
+    container_name: playwright-tests-container
+    working_dir: /app
+    command: sh /app/e2e/support/bamboo/e2e-test-runner.sh
+    volumes:
+      - ../../../:/app
+    networks:
+      - test
+
+  gateway:
+    image: openmrs/openmrs-reference-application-3-gateway:${TAG:-nightly}
+    depends_on:
+      - frontend
+      - backend
+    ports:
+      - "80:80"
+    networks:
+      - test
+
+  frontend:
+    image: openmrs/openmrs-reference-application-3-frontend:${TAG:-nightly}
+    environment:
+      SPA_PATH: /openmrs/spa
+      API_URL: /openmrs
+      SPA_CONFIG_URLS:
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost/" ]
+      timeout: 5s
+    depends_on:
+      - backend
+    networks:
+      - test
+
+  backend:
+    image: openmrs/openmrs-reference-application-3-backend:nightly-with-data
+    depends_on:
+      - db
+    networks:
+      - test
+  db:
+    image: openmrs/openmrs-reference-application-3-db:nightly-with-data
+    networks:
+      - test
+
+networks:
+  test:

--- a/e2e/support/bamboo/e2e-test-runner.sh
+++ b/e2e/support/bamboo/e2e-test-runner.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export E2E_BASE_URL=http://gateway/openmrs
+export CI=true
+
+while [ "$(curl -s -o /dev/null -w ''%{http_code}'' http://gateway/openmrs/login.htm)" != "200" ]; do
+  echo "Waiting for the backend to be up..."
+  sleep 10
+done
+
+yarn test-e2e

--- a/e2e/support/bamboo/playwright.Dockerfile
+++ b/e2e/support/bamboo/playwright.Dockerfile
@@ -1,0 +1,13 @@
+# The image version should match the Playwright version specified in the package.json file
+FROM mcr.microsoft.com/playwright:v1.53.2-jammy
+
+ARG USER_ID
+ARG GROUP_ID
+
+RUN if ! getent group $GROUP_ID > /dev/null; then \
+  groupadd -g $GROUP_ID myusergroup; \
+  fi
+
+RUN useradd -u $USER_ID -g $GROUP_ID -m playwrightuser
+
+USER playwrightuser

--- a/e2e/support/github/Dockerfile
+++ b/e2e/support/github/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.3
+FROM --platform=$BUILDPLATFORM node:22-alpine as dev
+
+ARG APP_SHELL_VERSION=next
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY . .
+
+RUN npm_config_legacy_peer_deps=true npm install -g openmrs@${APP_SHELL_VERSION:-next}
+ARG CACHE_BUST
+RUN npm_config_legacy_peer_deps=true openmrs assemble --manifest --mode config --config spa-assemble-config.json --target ./spa
+
+FROM --platform=$BUILDPLATFORM openmrs/openmrs-reference-application-3-frontend:nightly as frontend
+FROM nginx:1.23-alpine
+
+RUN apk update && \
+  apk upgrade && \
+  # add more utils for sponge to support our startup script
+  apk add --no-cache moreutils
+
+# clear any default files installed by nginx
+RUN rm -rf /usr/share/nginx/html/*
+
+COPY --from=frontend /etc/nginx/nginx.conf /etc/nginx/nginx.conf
+# this assumes that NOTHING in the framework is in a subdirectory
+COPY --from=frontend /usr/share/nginx/html/* /usr/share/nginx/html/
+COPY --from=frontend /usr/local/bin/startup.sh /usr/local/bin/startup.sh
+RUN chmod +x /usr/local/bin/startup.sh
+
+COPY --from=dev /app/spa/ /usr/share/nginx/html/
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/e2e/support/github/docker-compose.yml
+++ b/e2e/support/github/docker-compose.yml
@@ -1,0 +1,24 @@
+# This docker compose file is used to create a backend environment for the e2e.yml workflow. 
+# The images are pre-filled with data so that the backend environment can be started within a short time.
+version: "3.7"
+
+services:
+  gateway:
+    image: openmrs/openmrs-reference-application-3-gateway:${TAG:-nightly}
+    ports:
+      - "8080:80"
+
+  frontend:
+    build:
+      context: .
+    environment:
+      SPA_PATH: /openmrs/spa
+      API_URL: /openmrs
+
+  backend:
+    image: openmrs/openmrs-reference-application-3-backend:nightly-with-data
+    depends_on:
+      - db
+
+  db:
+    image: openmrs/openmrs-reference-application-3-db:nightly-with-data

--- a/e2e/support/github/run-e2e-docker-env.sh
+++ b/e2e/support/github/run-e2e-docker-env.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash -eu
+
+# get the dir containing the script
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# create a temporary working directory
+working_dir=$(mktemp -d "${TMPDIR:-/tmp/}openmrs-e2e-frontends.XXXXXXXXXX")
+# cleanup temp directory on exit
+trap 'rm -rf "$working_dir"' EXIT
+# get a list of all the apps in this workspace
+apps=$(yarn workspaces list --json | jq -r 'if .location | test("-app$") then .name else empty end')
+# this array will hold all of the packed app names
+app_names=()
+
+echo "Creating packed archives of apps..."
+# Pack each app into a tarball
+for app in $apps
+do
+  # Convert @openmrs/esm-whatever to _openmrs_esm_whatever
+  app_name=$(echo "$app" | tr '[:punct:]' '_');
+  # Add to our array
+  app_names+=("$app_name.tgz");
+  # Run yarn pack for our app and add it to the working directory
+  yarn workspace "$app" pack -o "$working_dir/$app_name.tgz" >/dev/null;
+done;
+echo "Created packed app archives"
+
+echo "Creating dynamic spa-assemble-config.json..."
+# Dynamically assemble our list of frontend modules, including core apps
+# (form-engine, home, patient-banner, patient-chart, patient-forms, primary-navigation)
+# and workspace apps; all apps will be in the /app directory of the Docker container
+jq -n \
+  --arg apps "$apps" \
+  --arg app_names "$(echo ${app_names[@]})" \
+  '{
+    "@openmrs/esm-form-engine-app": "next",
+    "@openmrs/esm-home-app": "next",
+    "@openmrs/esm-patient-banner-app": "next",
+    "@openmrs/esm-patient-chart-app": "next",
+    "@openmrs/esm-patient-forms-app": "next",
+    "@openmrs/esm-primary-navigation-app": "next",
+  } + (
+    ($apps | split("\n")) as $apps | ($app_names | split(" ") | map("/app/" + .)) as $app_files
+    | [$apps, $app_files]
+    | transpose
+    | map({"key": .[0], "value": .[1]})
+    | from_entries
+  )' | jq '{"frontendModules": .}' > "$working_dir/spa-assemble-config.json"
+echo "Created dynamic spa-assemble-config.json"
+
+echo "Copying Docker configuration files..."
+cp "$script_dir/Dockerfile" "$working_dir/Dockerfile"
+cp "$script_dir/docker-compose.yml" "$working_dir/docker-compose.yml"
+
+cd $working_dir
+echo "Building and starting Docker containers..."
+# CACHE_BUST to ensure the assemble step is always run
+docker compose build --build-arg CACHE_BUST=$(date +%s) frontend
+docker compose up -d

--- a/example.env
+++ b/example.env
@@ -1,0 +1,5 @@
+# This is an example environment file for configuring dynamic values.
+E2E_BASE_URL=http://localhost:8080/openmrs
+E2E_USER_ADMIN_USERNAME=admin
+E2E_USER_ADMIN_PASSWORD=Admin123
+E2E_DEFAULT_PROVIDER_NAME=Amoroso, Edward

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ci:prepublish": "yarn workspaces foreach --all --topological --exclude @pih/openmrs-esm-pihemr npm publish --access public --tag next",
     "release": "yarn workspaces foreach --all --topological version",
     "verify": "turbo lint typescript test --color --concurrency=2",
+    "test-e2e": "playwright test",
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx,css,scss}\" \"e2e/**/*.ts\" --list-different",
     "postinstall": "husky install",
     "extract-translations": "turbo extract-translations -- --config ../../tools/i18next-parser.config.js"
@@ -19,7 +20,7 @@
   "devDependencies": {
     "@carbon/react": "^1.83.0",
     "@openmrs/esm-framework": "next",
-    "@playwright/test": "^1.42.1",
+    "@playwright/test": "^1.53.2",
     "@swc/core": "^1.2.203",
     "@swc/jest": "^0.2.21",
     "@testing-library/dom": "^7.20.0",
@@ -35,6 +36,7 @@
     "@typescript-eslint/parser": "^6.21.0",
     "cross-env": "^7.0.3",
     "css-loader": "^6.7.1",
+    "dotenv": "^16.0.3",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",

--- a/packages/esm-commons-app/src/ward-app/o2-iframe.component.tsx
+++ b/packages/esm-commons-app/src/ward-app/o2-iframe.component.tsx
@@ -23,13 +23,7 @@ interface O2IFrame {
   customJavaScript?: string;
 }
 
-
-const O2IFrame: React.FC<O2IFrame> = ({
-  src,
-  elementsToHide,
-  elementsToDisable,
-  customJavaScript = '',
-}) => {
+const O2IFrame: React.FC<O2IFrame> = ({ src, elementsToHide, elementsToDisable, customJavaScript = '' }) => {
   const iframeRef = useRef<HTMLIFrameElement>();
   const [isIframeLoading, setIsIframeLoading] = useState(true);
   const [isGoingBack, setIsGoingBack] = useState(false);

--- a/packages/esm-commons-app/src/ward-app/o2-iframe.component.tsx
+++ b/packages/esm-commons-app/src/ward-app/o2-iframe.component.tsx
@@ -23,7 +23,13 @@ interface O2IFrame {
   customJavaScript?: string;
 }
 
-const O2IFrame: React.FC<O2IFrame> = ({ src, elementsToHide, elementsToDisable, customJavaScript = '' }) => {
+
+const O2IFrame: React.FC<O2IFrame> = ({
+  src,
+  elementsToHide,
+  elementsToDisable,
+  customJavaScript = '',
+}) => {
   const iframeRef = useRef<HTMLIFrameElement>();
   const [isIframeLoading, setIsIframeLoading] = useState(true);
   const [isGoingBack, setIsGoingBack] = useState(false);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,36 @@
+import { devices, type PlaywrightTestConfig } from '@playwright/test';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+// See https://playwright.dev/docs/test-configuration.
+const config: PlaywrightTestConfig = {
+  testDir: './e2e/specs',
+  timeout: 3 * 60 * 1000,
+  expect: {
+    timeout: 40 * 1000,
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: process.env.CI ? [['junit', { outputFile: 'results.xml' }], ['html']] : [['html']],
+  globalSetup: require.resolve('./e2e/core/global-setup'),
+  use: {
+    baseURL: `${process.env.E2E_BASE_URL}/spa/`,
+    storageState: 'e2e/storageState.json',
+    video: 'retain-on-failure',
+    trace: 'retain-on-failure',
+    launchOptions: {
+      slowMo: 250,
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+};
+
+export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4286,7 +4286,7 @@ __metadata:
   dependencies:
     "@carbon/react": "npm:^1.83.0"
     "@openmrs/esm-framework": "npm:next"
-    "@playwright/test": "npm:^1.42.1"
+    "@playwright/test": "npm:^1.53.2"
     "@swc/core": "npm:^1.2.203"
     "@swc/jest": "npm:^0.2.21"
     "@testing-library/dom": "npm:^7.20.0"
@@ -4302,6 +4302,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^6.21.0"
     cross-env: "npm:^7.0.3"
     css-loader: "npm:^6.7.1"
+    dotenv: "npm:^16.0.3"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-prettier: "npm:^5.1.3"
@@ -4344,14 +4345,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.42.1":
-  version: 1.42.1
-  resolution: "@playwright/test@npm:1.42.1"
+"@playwright/test@npm:^1.53.2":
+  version: 1.58.2
+  resolution: "@playwright/test@npm:1.58.2"
   dependencies:
-    playwright: "npm:1.42.1"
+    playwright: "npm:1.58.2"
   bin:
     playwright: cli.js
-  checksum: 10/5bd7f1c77963cacc6f44cf4c1ef46f9ad41e79a3e6f34eb81398afaa09b1b08a4cbe0f7064f03c71c094414d1c4507d6183b61c63aa4b6a93846d386f7c651a2
+  checksum: 10/58bf90139280a0235eeeb6049e9fb4db6425e98be1bf0cc17913b068eef616cf67be57bfb36dc4cb56bcf116f498ffd0225c4916e85db404b343ea6c5efdae13
   languageName: node
   linkType: hard
 
@@ -11229,6 +11230,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^16.0.3":
+  version: 16.6.1
+  resolution: "dotenv@npm:16.6.1"
+  checksum: 10/1d1897144344447ffe62aa1a6d664f4cd2e0784e0aff787eeeec1940ded32f8e4b5b506d665134fc87157baa086fce07ec6383970a2b6d2e7985beaed6a4cc14
+  languageName: node
+  linkType: hard
+
 "downshift@npm:8.1.0":
   version: 8.1.0
   resolution: "downshift@npm:8.1.0"
@@ -17030,27 +17038,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.42.1":
-  version: 1.42.1
-  resolution: "playwright-core@npm:1.42.1"
+"playwright-core@npm:1.58.2":
+  version: 1.58.2
+  resolution: "playwright-core@npm:1.58.2"
   bin:
     playwright-core: cli.js
-  checksum: 10/6a71d2e2aa5b054d6e83836f09e139a0ff4de3aa9b6aebe0e03de3ab828c735d23a20a60fafcee91c1658da490cc390f05af463325ac842beaff58a173f7ad9e
+  checksum: 10/8a98fcf122167e8703d525db2252de0e3da4ab9110ab6ea9951247e52d846310eb25ea2c805e1b7ccb54b4010c44e5adc3a76aae6da02f34324ccc3e76683bb1
   languageName: node
   linkType: hard
 
-"playwright@npm:1.42.1":
-  version: 1.42.1
-  resolution: "playwright@npm:1.42.1"
+"playwright@npm:1.58.2":
+  version: 1.58.2
+  resolution: "playwright@npm:1.58.2"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.42.1"
+    playwright-core: "npm:1.58.2"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10/1f866a6820e19feaaeb12cd87bfa93299d6d72e1287413098c5ae0349c7e7953eb0a303bdfbb99c12173a3493e6fdb642f89a166cfcfd8295254a520abf6eb7f
+  checksum: 10/d89d6c8a32388911b9aff9ee0f1a90076219f15c804f2b287db048b9e9cde182aea3131fac1959051d25189ed4218ec4272b137c83cd7f9cd24781cbc77edd86
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

The O3 Ward App currently has some E2E test, but they run against the refapp. This PR adds tests against KGH.. While there is some overlap between the existing E2E tests (a bunch of helper functions are copied from there), there are also some tests steps that are specific to KGH, like the O2 MCH Triage and Maternal Admission forms. 

Some TODOs not in this PR:
- This is not hooked up to Github Action yet, so we have to run the tests locally
- The element selectors for the O2 forms are flaky (ex: `select[name="w1"]`) and will break when we add / remove form fields. 

 

## Screenshots
One of the tests in action:
[Screencast from 2026-03-09 15-03-04.webm](https://github.com/user-attachments/assets/3245932b-1b66-40c1-82af-d03bf62523d7)

## Related Issue

