### PR TITLE
UHM-9178 add E2E tests for service queues app

### DIFF
--- a/e2e/commands/patient-operations.ts
+++ b/e2e/commands/patient-operations.ts
@@ -142,6 +142,7 @@ export const getPatient = async (api: APIRequestContext, uuid: string): Promise<
 
 export const deletePatient = async (api: APIRequestContext, uuid: string) => {
   const response = await api.delete(`patient/${uuid}`);
+  const text = await response.text();
   await expect(response.ok()).toBeTruthy();
 };
 

--- a/e2e/commands/visit-operations.ts
+++ b/e2e/commands/visit-operations.ts
@@ -26,7 +26,6 @@ export const endVisit = async (api: APIRequestContext, uuid: string, isWardTest 
   await api.post(`visit/${uuid}`, {
     data: {
       location: isWardTest ? process.env.E2E_WARD_LOCATION_UUID : process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
-      startDatetime: dayjs().subtract(1, 'D').format('YYYY-MM-DDTHH:mm:ss.SSSZZ'),
       visitType: KGHVisitType,
       stopDatetime: dayjs().format('YYYY-MM-DDTHH:mm:ss.SSSZZ'),
     },

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,1 +1,2 @@
 export * from './ward-page';
+export * from './service-queues-page';

--- a/e2e/pages/service-queues-page.ts
+++ b/e2e/pages/service-queues-page.ts
@@ -1,0 +1,173 @@
+import { expect, type Page } from '@playwright/test';
+import { step, test } from '../core';
+
+export class ServiceQueuesPage {
+  private constructor(readonly page: Page) {}
+
+  // ── Header / toolbar ──────────────────────────────────────────────────────
+  readonly addPatientToQueueButton = () => this.page.getByRole('button', { name: 'Add patient to queue' }).first();
+
+  // ── Add-patient workspace ─────────────────────────────────────────────────
+  readonly patientSearchBar = () => this.page.getByTestId('patientSearchBar');
+  readonly searchButton = () => this.page.getByRole('button', { name: 'Search', exact: true });
+  readonly discardButton = () => this.page.getByRole('button', { name: 'Discard', exact: true });
+  // Submit inside the form — scoped to avoid matching the header "Add patient to queue" button
+  readonly submitAddPatientButton = () =>
+    this.page.locator('form').getByRole('button', { name: 'Add patient to queue' });
+
+  patientSearchResult(patientIdentifier: string) {
+    // Patient result cards render as role="banner" (i.e. <header>) in the search results panel
+    return this.page.getByRole('banner').filter({ hasText: patientIdentifier });
+  }
+
+  // ── Queue table rows ───────────────────────────────────────────────────────
+  waitingRow(patientName: string) {
+    return this.page
+      .locator('table[aria-label="Queue table"]')
+      .filter({ hasText: 'Wait time' })
+      .getByRole('row')
+      .filter({ hasText: patientName });
+  }
+
+  inServiceRow(patientName: string) {
+    return this.page
+      .locator('table[aria-label="Queue table"]')
+      .filter({ hasText: 'Time in service' })
+      .getByRole('row')
+      .filter({ hasText: patientName });
+  }
+
+  triageButton(patientName: string) {
+    return this.waitingRow(patientName).getByRole('button', { name: 'Triage' });
+  }
+
+  overflowMenuButton(patientName: string) {
+    return this.page
+      .locator('table[aria-label="Queue table"] tr')
+      .filter({ hasText: patientName })
+      .first()
+      .getByRole('button', { name: 'Options' });
+  }
+
+  overflowMenuItem(itemText: string) {
+    return this.page.getByRole('menuitem', { name: itemText });
+  }
+
+  // ── Confirmation modal buttons ────────────────────────────────────────────
+  readonly confirmRemoveButton = () => this.page.getByRole('button', { name: 'Remove' });
+  readonly confirmDeleteButton = () => this.page.getByRole('button', { name: 'Delete queue entry' });
+  readonly confirmUndoTransitionButton = () => this.page.getByRole('button', { name: 'Undo transition' });
+
+  // ── Navigation ────────────────────────────────────────────────────────────
+  @step
+  static async open(page: Page) {
+    return test.step('When I navigate to the service queues page', async () => {
+      const serviceQueuesPage = new ServiceQueuesPage(page);
+      await page.goto('/openmrs/spa/home/service-queues/queue-table-by-status/3113f164-68f0-11ee-ab8d-0242ac120002');
+      await page.getByRole('button', { name: 'Add patient to queue' }).first().waitFor({ state: 'visible' });
+      return serviceQueuesPage;
+    });
+  }
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+  @step
+  async addPatientToQueue(patientIdentifier: string) {
+    return test.step(`When I add patient ${patientIdentifier} to the queue`, async () => {
+      await this.addPatientToQueueButton().click();
+      await this.patientSearchBar().fill(patientIdentifier);
+      await this.searchButton().click();
+      await this.patientSearchResult(patientIdentifier).waitFor({ state: 'visible' });
+      await this.patientSearchResult(patientIdentifier).click();
+      await this.page.locator('select#queueService').selectOption({ label: 'MCOE Triage' });
+      await this.submitAddPatientButton().click();
+    });
+  }
+
+  @step
+  async triagePatient(patientName: string) {
+    return test.step(`When I triage patient ${patientName}`, async () => {
+      await this.triageButton(patientName).click();
+      // Clicking Triage immediately transitions the patient to "In service"
+      // and opens the triage form workspace as a side effect.
+    });
+  }
+
+  @step
+  async dismissWorkspace() {
+    return test.step('When I dismiss the open workspace', async () => {
+      await this.page.getByLabel('Close', { exact: true }).click();
+      await this.page.getByRole('button', { name: 'Discard changes' }).click();
+    });
+  }
+
+  @step
+  async removePatientFromQueue(patientName: string) {
+    return test.step(`When I remove patient ${patientName} from the queue`, async () => {
+      await this.overflowMenuButton(patientName).click();
+      await this.overflowMenuItem('Remove patient').click();
+      await this.confirmRemoveButton().click();
+    });
+  }
+
+  @step
+  async deletePatientFromQueue(patientName: string) {
+    return test.step(`When I delete patient ${patientName} from the queue`, async () => {
+      await this.overflowMenuButton(patientName).click();
+      await this.overflowMenuItem('Delete').click();
+      await this.confirmDeleteButton().click();
+    });
+  }
+
+  @step
+  async undoQueueTransition(patientName: string) {
+    return test.step(`When I undo the queue transition for patient ${patientName}`, async () => {
+      await this.overflowMenuButton(patientName).click();
+      await this.overflowMenuItem('Undo transition').click();
+      await this.confirmUndoTransitionButton().click();
+    });
+  }
+
+  // ── Assertions ────────────────────────────────────────────────────────────
+  @step
+  async expectPatientInWaitingQueue(patientName: string) {
+    return test.step(`Then I should see ${patientName} added to the waiting queue`, async () => {
+      await expect(this.waitingRow(patientName)).toBeVisible();
+    });
+  }
+
+  @step
+  async expectPatientInInServiceQueue(patientName: string) {
+    return test.step(`Then I should see ${patientName} in the In service table`, async () => {
+      await expect(this.inServiceRow(patientName)).toBeVisible();
+    });
+  }
+
+  @step
+  async expectPatientRemovedFromQueue(patientName: string) {
+    return test.step(`Then I should see ${patientName} removed from the queue`, async () => {
+      await expect(this.page.getByText('Patient removed')).toBeVisible();
+      await expect(this.waitingRow(patientName)).not.toBeVisible();
+    });
+  }
+
+  @step
+  async expectPatientDeletedFromQueue(patientName: string) {
+    return test.step(`Then I should see ${patientName} deleted from the queue`, async () => {
+      await expect(this.page.getByText('Queue entry deleted successfully')).toBeVisible();
+    });
+  }
+
+  @step
+  async expectTransitionUndone(patientName: string) {
+    return test.step(`Then I should see ${patientName} moved back to Waiting`, async () => {
+      await expect(this.page.getByText('Undo transition success')).toBeVisible();
+      await expect(this.waitingRow(patientName)).toBeVisible();
+    });
+  }
+
+  async expectPatientNotInWaitingQueue(patientName: string) {
+    return test.step(`Then I should not see ${patientName} in the waiting queue`, async () => {
+      await expect(this.waitingRow(patientName)).not.toBeVisible();
+    });
+  }
+}

--- a/e2e/specs/service-queues/queue-actions.spec.ts
+++ b/e2e/specs/service-queues/queue-actions.spec.ts
@@ -1,0 +1,60 @@
+import { changeLocation, getPatientIdentifierStr, getPatientName } from '../../commands';
+import { KGHLocationsUuids, test } from '../../core';
+import { ServiceQueuesPage } from '../../pages/service-queues-page';
+
+test.describe('Service Queues', () => {
+  test.beforeEach(async ({ api }) => {
+    await changeLocation(api, KGHLocationsUuids['MCOE Triage']);
+  });
+
+  test('Add a patient to the Triage Queue, triage them into "in-service" status, then undo', async ({
+    page,
+    adultWoman,
+    adultWomanVisit,
+  }) => {
+    const patientName = getPatientName(adultWoman);
+    const patientIdentifier = getPatientIdentifierStr(adultWoman);
+
+    const serviceQueuesPage = await ServiceQueuesPage.open(page);
+
+    await serviceQueuesPage.addPatientToQueue(patientIdentifier);
+
+    await serviceQueuesPage.expectPatientInWaitingQueue(patientName);
+    await serviceQueuesPage.triagePatient(patientName);
+
+    await page.reload();
+
+    await serviceQueuesPage.expectPatientInInServiceQueue(patientName);
+
+    await serviceQueuesPage.dismissWorkspace();
+
+    await serviceQueuesPage.undoQueueTransition(patientName);
+    await serviceQueuesPage.expectPatientInWaitingQueue(patientName);
+  });
+
+  test('Add a patient to the Triage Queue, then remove them', async ({ page, adultWoman, adultWomanVisit }) => {
+    const patientName = getPatientName(adultWoman);
+    const patientIdentifier = getPatientIdentifierStr(adultWoman);
+
+    const serviceQueuesPage = await ServiceQueuesPage.open(page);
+
+    await serviceQueuesPage.addPatientToQueue(patientIdentifier);
+
+    await serviceQueuesPage.expectPatientInWaitingQueue(patientName);
+    await serviceQueuesPage.removePatientFromQueue(patientName);
+    await serviceQueuesPage.expectPatientNotInWaitingQueue(patientName);
+  });
+
+  test('Add a patient to the Triage Queue, then delete them', async ({ page, adultWoman, adultWomanVisit }) => {
+    const patientName = getPatientName(adultWoman);
+    const patientIdentifier = getPatientIdentifierStr(adultWoman);
+
+    const serviceQueuesPage = await ServiceQueuesPage.open(page);
+
+    await serviceQueuesPage.addPatientToQueue(patientIdentifier);
+
+    await serviceQueuesPage.expectPatientInWaitingQueue(patientName);
+    await serviceQueuesPage.deletePatientFromQueue(patientName);
+    await serviceQueuesPage.expectPatientNotInWaitingQueue(patientName);
+  });
+});

--- a/e2e/specs/service-queues/queue-actions.spec.ts
+++ b/e2e/specs/service-queues/queue-actions.spec.ts
@@ -22,8 +22,6 @@ test.describe('Service Queues', () => {
     await serviceQueuesPage.expectPatientInWaitingQueue(patientName);
     await serviceQueuesPage.triagePatient(patientName);
 
-    await page.reload();
-
     await serviceQueuesPage.expectPatientInInServiceQueue(patientName);
 
     await serviceQueuesPage.dismissWorkspace();

--- a/packages/esm-commons-app/src/service-queues-app/maternal-triage-queue-actions.resource.ts
+++ b/packages/esm-commons-app/src/service-queues-app/maternal-triage-queue-actions.resource.ts
@@ -1,24 +1,28 @@
 import { type Concept, type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { useSWRConfig } from 'swr';
 import { type QueueEntry } from './types';
+import { useCallback, useMemo } from 'react';
 
 // Hooks here copied from esm-service-queues-app
 
 export function useMutateQueueEntries() {
-  const { mutate } = useSWRConfig();
+  const { mutate, cache } = useSWRConfig();
+  const mutateQueueEntries = useCallback(() => {
+    const promises: Promise<unknown>[] = [];
+    for (const key of cache.keys()) {
+      if (key.includes(`${restBaseUrl}/queue-entry`) || key.includes(`${restBaseUrl}/visit-queue-entry`)) {
+        promises.push(mutate(key));
+      }
+    }
+    return Promise.all(promises);
+  }, [mutate, cache]);
 
-  return {
-    mutateQueueEntries: () => {
-      return mutate((key) => {
-        return (
-          typeof key === 'string' &&
-          (key.includes(`${restBaseUrl}/queue-entry`) || key.includes(`${restBaseUrl}/visit-queue-entry`))
-        );
-      }).then(() => {
-        window.dispatchEvent(new CustomEvent('queue-entry-updated'));
-      });
-    },
-  };
+  return useMemo(
+    () => ({
+      mutateQueueEntries,
+    }),
+    [mutateQueueEntries],
+  );
 }
 
 interface TransitionQueueEntryParams {


### PR DESCRIPTION
## Summary

Adds e2e service queues tests:
- Add a patient to the Triage Queue
- Triage a patient 
- Remove Patient from queue
- Delete patient from queue
- Undo queue transition 

## Screenshots

## Related Issue
