### PR TITLE
UHM-9178 fix queues app mutation hook

### DIFF
--- a/e2e/pages/service-queues-page.ts
+++ b/e2e/pages/service-queues-page.ts
@@ -165,6 +165,7 @@ export class ServiceQueuesPage {
     });
   }
 
+  @step
   async expectPatientNotInWaitingQueue(patientName: string) {
     return test.step(`Then I should not see ${patientName} in the waiting queue`, async () => {
       await expect(this.waitingRow(patientName)).not.toBeVisible();

--- a/packages/esm-commons-app/package.json
+++ b/packages/esm-commons-app/package.json
@@ -45,7 +45,8 @@
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
     "react": "18.x",
-    "react-i18next": "16.x"
+    "react-i18next": "16.x",
+    "swr": "2.x"
   },
   "devDependencies": {
     "webpack": "^5.74.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4217,6 +4217,7 @@ __metadata:
     "@openmrs/esm-framework": 5.x
     react: 18.x
     react-i18next: 16.x
+    swr: 2.x
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

When we click the "triage" button on a queues row, the patient should immediately be moved from the "Waiting" status to the "In service" status. The mutate data hook was not fixed properly in the last PR, so the patient looks to be stuck in the "Waiting" status. This PR fixes it.

<img width="1757" height="1070" alt="image" src="https://github.com/user-attachments/assets/84a533eb-0b44-4ce9-a3c7-d8e065582bf7" />


Explanation by Claude:
  1. esm-commons-app had no swr peer dep → rspack bundled its own private copy
  2. useSWRConfig() returned that private instance's cache — always empty
  3. esm-service-queues-app and @openmrs/esm-react-utils both declared swr: 2.x as a peer dep → their builds registered it as a shared singleton
  4. All queue entry data was cached in the shared singleton, invisible to esm-commons-app's isolated copy

 

## Screenshots

## Related Issue
