### PR TITLE
SL-1265: add vitals table at the top of the vitals form

### DIFF
--- a/packages/esm-commons-app/src/config-schema.ts
+++ b/packages/esm-commons-app/src/config-schema.ts
@@ -1,0 +1,33 @@
+import { Type } from '@openmrs/esm-framework';
+
+/**
+ * In OpenMRS Microfrontends, all config parameters are optional.
+ * Reasonable defaults are required so the app works in the reference application.
+ */
+export const configSchema = {
+  concepts: {
+    hemoglobinUuid: {
+      _type: Type.ConceptUuid,
+      _default: '3ccc7158-26fe-102b-80cb-0017a47871b2',
+      _description: 'UUID for the Hemoglobin concept',
+    },
+    glucoseUuid: {
+      _type: Type.ConceptUuid,
+      _default: '0e9d36ab-ccfe-4716-9060-ad5f330a28af',
+      _description: 'UUID for the Glucose concept',
+    },
+    fhrUuid: {
+      _type: Type.ConceptUuid,
+      _default: '1440AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      _description: 'UUID for the Fetal heart rate concept',
+    },
+  },
+};
+
+export interface ConfigObject {
+  concepts: {
+    hemoglobinUuid: string;
+    glucoseUuid: string;
+    fhrUuid: string;
+  };
+}

--- a/packages/esm-commons-app/src/hooks/useConceptReferenceRanges.ts
+++ b/packages/esm-commons-app/src/hooks/useConceptReferenceRanges.ts
@@ -1,0 +1,128 @@
+import useSWRImmutable from 'swr/immutable';
+import { restBaseUrl, openmrsFetch } from '@openmrs/esm-framework';
+
+export type ObservationInterpretation =
+  | 'normal'
+  | 'high'
+  | 'critically_high'
+  | 'off_scale_high'
+  | 'low'
+  | 'critically_low'
+  | 'off_scale_low';
+
+export type ReferenceRangeValue = number | null | undefined;
+
+export interface ObsReferenceRanges {
+  hiAbsolute: ReferenceRangeValue;
+  hiCritical: ReferenceRangeValue;
+  hiNormal: ReferenceRangeValue;
+  lowNormal: ReferenceRangeValue;
+  lowCritical: ReferenceRangeValue;
+  lowAbsolute: ReferenceRangeValue;
+}
+
+interface ConceptReferenceRangeResponse {
+  results: Array<{
+    concept: string;
+    display: string;
+    hiNormal?: number | null;
+    hiAbsolute?: number | null;
+    hiCritical?: number | null;
+    lowNormal?: number | null;
+    lowAbsolute?: number | null;
+    lowCritical?: number | null;
+    units?: string | null;
+  }>;
+}
+
+async function fetchReferenceRange(
+  conceptUuid: string,
+  patientUuid: string | undefined,
+): Promise<ObsReferenceRanges | undefined> {
+  const url = `${restBaseUrl}/conceptreferencerange/?concept=${conceptUuid}&v=full${
+    patientUuid ? `&patient=${patientUuid}` : ''
+  }`;
+  const response = await openmrsFetch<ConceptReferenceRangeResponse>(url);
+  const conceptData = response.data?.results?.[0];
+
+  if (!conceptData) {
+    return undefined;
+  }
+
+  return {
+    hiNormal: conceptData.hiNormal ?? null,
+    hiAbsolute: conceptData.hiAbsolute ?? null,
+    hiCritical: conceptData.hiCritical ?? null,
+    lowNormal: conceptData.lowNormal ?? null,
+    lowAbsolute: conceptData.lowAbsolute ?? null,
+    lowCritical: conceptData.lowCritical ?? null,
+  };
+}
+
+export function calculateInterpretation(
+  value: string | number | object | undefined,
+  range?: ObsReferenceRanges,
+): ObservationInterpretation {
+  if (!range || value === undefined || value === null || value === '') {
+    return 'normal';
+  }
+
+  const numericValue =
+    typeof value === 'string' ? Number.parseFloat(value) : typeof value === 'number' ? value : undefined;
+
+  if (numericValue === undefined || Number.isNaN(numericValue)) {
+    return 'normal';
+  }
+
+  if (Number.isNaN(numericValue)) {
+    return 'normal';
+  }
+
+  if (range.hiAbsolute !== null && range.hiAbsolute !== undefined && numericValue > range.hiAbsolute) {
+    return 'off_scale_high';
+  }
+
+  if (range.hiCritical !== null && range.hiCritical !== undefined && numericValue >= range.hiCritical) {
+    return 'critically_high';
+  }
+
+  if (range.hiNormal !== null && range.hiNormal !== undefined && numericValue > range.hiNormal) {
+    return 'high';
+  }
+
+  if (range.lowAbsolute !== null && range.lowAbsolute !== undefined && numericValue < range.lowAbsolute) {
+    return 'off_scale_low';
+  }
+
+  if (range.lowCritical !== null && range.lowCritical !== undefined && numericValue <= range.lowCritical) {
+    return 'critically_low';
+  }
+
+  if (range.lowNormal !== null && range.lowNormal !== undefined && numericValue < range.lowNormal) {
+    return 'low';
+  }
+
+  return 'normal';
+}
+
+export function useConceptReferenceRanges(patientUuid: string | undefined, conceptUuids: string[]) {
+  const stableConceptUuids = conceptUuids.filter(Boolean).sort();
+  const shouldFetch = Boolean(patientUuid && stableConceptUuids.length > 0);
+  const cacheKey = shouldFetch ? ['conceptReferenceRanges', patientUuid, stableConceptUuids.join(',')] : null;
+
+  const { data, error, isLoading } = useSWRImmutable(cacheKey, async () => {
+    const entries = await Promise.all(
+      stableConceptUuids.map(
+        async (conceptUuid) => [conceptUuid, await fetchReferenceRange(conceptUuid, patientUuid)] as const,
+      ),
+    );
+
+    return Object.fromEntries(entries.filter(([, range]) => range !== undefined)) as Record<string, ObsReferenceRanges>;
+  });
+
+  return {
+    referenceRangeMap: data ?? {},
+    error,
+    isLoading,
+  };
+}

--- a/packages/esm-commons-app/src/index.ts
+++ b/packages/esm-commons-app/src/index.ts
@@ -5,7 +5,8 @@
  * microfrontend.
  */
 
-import { getAsyncLifecycle } from '@openmrs/esm-framework';
+import { getAsyncLifecycle, defineConfigSchema } from '@openmrs/esm-framework';
+import { configSchema } from './config-schema';
 
 const moduleName = '@pih/esm-commons-app';
 
@@ -46,4 +47,6 @@ export const triageWaitingQueueActions = getAsyncLifecycle(
   { featureName: 'triageWaitingQueueActions', moduleName },
 );
 
-export function startupApp() {}
+export function startupApp() {
+  defineConfigSchema(moduleName, configSchema);
+}

--- a/packages/esm-commons-app/src/ward-app/VitalsTable.tsx
+++ b/packages/esm-commons-app/src/ward-app/VitalsTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DataTable,
@@ -9,8 +9,10 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  Button,
 } from '@carbon/react';
-import { openmrsFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, useConfig, usePagination } from '@openmrs/esm-framework';
+import { Pagination } from '@openmrs/esm-styleguide';
 import useSWR from 'swr';
 import dayjs from 'dayjs';
 
@@ -62,19 +64,12 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
     fhr: localConcepts.fhrUuid,
   };
   const { t } = useTranslation();
+  const [showAll, setShowAll] = useState(false);
 
   const { data: vitalsData, error } = useSWR<EncounterResponse>(
     `${restBaseUrl}/encounter?patient=${patientUuid}&visit=${visitUuid}&order=desc&v=${customRepresentation}`,
-    (url) => openmrsFetch(url).then((res) => res.data),
+    (url: string) => openmrsFetch(url).then((res) => res.data),
   );
-
-  if (error) {
-    return <div>{t('errorLoadingVitals', 'Error loading vitals')}</div>;
-  }
-
-  if (!vitalsData) {
-    return <div>{t('loadingVitals', 'Loading vitals...')}</div>;
-  }
 
   const encounters: Encounter[] = vitalsData?.results || [];
 
@@ -84,31 +79,48 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
   });
 
   // Process each encounter to extract vital signs
-  const tableRows = encountersWithVitals.map((encounter) => {
-    const vitalsMap = encounter.obs.reduce(
-      (acc, obs) => {
-        acc[obs.concept.uuid] = obs.value;
-        return acc;
-      },
-      {} as Record<string, number | string | object | null>,
-    );
+  const tableRows = useMemo(
+    () =>
+      encountersWithVitals.map((encounter) => {
+        const vitalsMap = encounter.obs.reduce(
+          (acc, obs) => {
+            acc[obs.concept.uuid] = obs.value;
+            return acc;
+          },
+          {} as Record<string, number | string | object | null>,
+        );
 
-    const systolic = vitalsMap[vitalsConcepts.systolic];
-    const diastolic = vitalsMap[vitalsConcepts.diastolic];
+        const systolic = vitalsMap[vitalsConcepts.systolic];
+        const diastolic = vitalsMap[vitalsConcepts.diastolic];
 
-    return {
-      id: encounter.uuid,
-      date: dayjs(encounter.encounterDatetime).format('DD/MM/YYYY HH:mm'),
-      bp: systolic && diastolic ? `${systolic}/${diastolic}` : '',
-      pulse: vitalsMap[vitalsConcepts.pulse] || '',
-      temperature: vitalsMap[vitalsConcepts.temperature] || '',
-      oxygenSaturation: vitalsMap[vitalsConcepts.oxygenSaturation] || '',
-      respiratoryRate: vitalsMap[vitalsConcepts.respiratoryRate] || '',
-      hemoglobin: vitalsMap[vitalsConcepts.hemoglobin] || '',
-      glucose: vitalsMap[vitalsConcepts.glucose] || '',
-      fhr: vitalsMap[vitalsConcepts.fhr] || '',
-    };
-  });
+        return {
+          id: encounter.uuid,
+          date: dayjs(encounter.encounterDatetime).format('DD/MM/YYYY HH:mm'),
+          bp: systolic && diastolic ? `${systolic}/${diastolic}` : '',
+          pulse: vitalsMap[vitalsConcepts.pulse] || '',
+          temperature: vitalsMap[vitalsConcepts.temperature] || '',
+          oxygenSaturation: vitalsMap[vitalsConcepts.oxygenSaturation] || '',
+          respiratoryRate: vitalsMap[vitalsConcepts.respiratoryRate] || '',
+          hemoglobin: vitalsMap[vitalsConcepts.hemoglobin] || '',
+          glucose: vitalsMap[vitalsConcepts.glucose] || '',
+          fhr: vitalsMap[vitalsConcepts.fhr] || '',
+        };
+      }),
+    [encountersWithVitals, vitalsConcepts],
+  );
+
+  const pageSize = 5;
+  const { results: paginatedVitals, currentPage, goTo } = usePagination(tableRows, pageSize);
+
+  const displayedRows = showAll ? tableRows : paginatedVitals;
+
+  if (error) {
+    return <div>{t('errorLoadingVitals', 'Error loading vitals')}</div>;
+  }
+
+  if (!vitalsData) {
+    return <div>{t('loadingVitals', 'Loading vitals...')}</div>;
+  }
 
   const tableHeaders = [
     { key: 'date', header: t('date', 'Date') },
@@ -123,32 +135,53 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
   ];
 
   return (
-    <DataTable headers={tableHeaders} rows={tableRows} size="sm" useZebraStyles>
-      {({ rows, headers, getTableProps, getHeaderProps, getRowProps }) => (
-        <TableContainer>
-          <Table {...getTableProps()}>
-            <TableHead>
-              <TableRow>
-                {headers.map((header) => (
-                  <TableHeader {...getHeaderProps({ header })} key={header.key}>
-                    {header.header}
-                  </TableHeader>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {rows.map((row) => (
-                <TableRow {...getRowProps({ row })} key={row.id}>
-                  {row.cells.map((cell) => (
-                    <TableCell key={cell.id}>{cell.value}</TableCell>
+    <>
+      <DataTable headers={tableHeaders} rows={displayedRows} size="sm" useZebraStyles>
+        {({ rows, headers, getTableProps, getHeaderProps, getRowProps }) => (
+          <TableContainer>
+            <Table {...getTableProps()}>
+              <TableHead>
+                <TableRow>
+                  {headers.map((header) => (
+                    <TableHeader {...getHeaderProps({ header })} key={header.key}>
+                      {header.header}
+                    </TableHeader>
                   ))}
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      )}
-    </DataTable>
+              </TableHead>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow {...getRowProps({ row })} key={row.id}>
+                    {row.cells.map((cell) => (
+                      <TableCell key={cell.id}>{cell.value}</TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DataTable>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '1rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginLeft: '1rem' }}>
+          <span style={{ fontSize: '0.875rem', color: '#6f6f6f' }}>
+            {displayedRows.length} / {tableRows.length} {t('items', 'items')}
+          </span>
+          <Button kind="ghost" size="sm" onClick={() => setShowAll(!showAll)}>
+            {showAll ? t('showPaginated', 'Show Paginated') : t('showAll', 'Show All')}
+          </Button>
+        </div>
+        {!showAll && (
+          <Pagination
+            pageNumber={currentPage}
+            totalItems={tableRows.length}
+            currentItems={paginatedVitals.length}
+            pageSize={pageSize}
+            onPageNumberChange={({ page }) => goTo(page)}
+          />
+        )}
+      </div>
+    </>
   );
 };
 

--- a/packages/esm-commons-app/src/ward-app/VitalsTable.tsx
+++ b/packages/esm-commons-app/src/ward-app/VitalsTable.tsx
@@ -36,10 +36,19 @@ interface Observation {
   value: number | string | object | null;
 }
 
+interface EncounterProvider {
+  provider: {
+    person: {
+      display: string;
+    };
+  };
+}
+
 interface Encounter {
   uuid: string;
   display: string;
   encounterDatetime: string;
+  encounterProviders?: EncounterProvider[];
   obs: Observation[];
 }
 
@@ -47,7 +56,8 @@ interface EncounterResponse {
   results: Encounter[];
 }
 
-const customRepresentation = 'custom:(uuid,display,encounterDatetime,obs:(uuid,concept:(uuid,name:(display)),value))';
+const customRepresentation =
+  'custom:(uuid,display,encounterDatetime,encounterProviders:(provider:(person:(display))),obs:(uuid,concept:(uuid,name:(display)),value))';
 
 const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => {
   const { concepts: externalConcepts } = useConfig<{ concepts: Record<string, string> }>({
@@ -98,9 +108,10 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
     hemoglobin?: VitalCellData;
     glucose?: VitalCellData;
     fhr?: VitalCellData;
+    provider?: string;
   }
 
-  type VitalColumnKey = Exclude<keyof VitalRowData, 'id' | 'date'>;
+  type VitalColumnKey = Exclude<keyof VitalRowData, 'id' | 'date' | 'provider'>;
 
   const createVitalCellData = (value: number | string | object | null, conceptUuid?: string): VitalCellData => {
     if (value === null || value === undefined) {
@@ -199,6 +210,8 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
       {} as Record<string, number | string | object | null>,
     );
 
+    const providerName = encounter.encounterProviders?.[0]?.provider?.person?.display || '—';
+
     return {
       id: encounter.uuid,
       date: dayjs(encounter.encounterDatetime).format('DD/MM/YYYY HH:mm'),
@@ -216,6 +229,7 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
       hemoglobin: createVitalCellData(vitalsMap[vitalsConcepts.hemoglobin], vitalsConcepts.hemoglobin),
       glucose: createVitalCellData(vitalsMap[vitalsConcepts.glucose], vitalsConcepts.glucose),
       fhr: createVitalCellData(vitalsMap[vitalsConcepts.fhr], vitalsConcepts.fhr),
+      provider: providerName,
     };
   };
 
@@ -252,6 +266,7 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
   const tableHeaders = [
     { key: 'date', header: t('date', 'Date') },
     ...vitalColumns.map((col) => ({ key: col.key, header: col.label })),
+    { key: 'provider', header: t('provider', 'Provider') },
   ];
 
   return (
@@ -276,7 +291,7 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
                   return (
                     <TableRow {...getRowProps({ row })} key={row.id}>
                       {row.cells.map((cell) => {
-                        if (cell.info.header === 'date') {
+                        if (cell.info.header === 'date' || cell.info.header === 'provider') {
                           return <TableCell key={cell.id}>{cell.value}</TableCell>;
                         }
 

--- a/packages/esm-commons-app/src/ward-app/VitalsTable.tsx
+++ b/packages/esm-commons-app/src/ward-app/VitalsTable.tsx
@@ -11,9 +11,13 @@ import {
   TableRow,
   Button,
 } from '@carbon/react';
-import { openmrsFetch, restBaseUrl, useConfig, usePagination } from '@openmrs/esm-framework';
-import { Pagination } from '@openmrs/esm-styleguide';
-import useSWR from 'swr';
+import { restBaseUrl, useConfig, useOpenmrsFetchAll, usePagination } from '@openmrs/esm-framework';
+import { Pagination, NumericObservation } from '@openmrs/esm-styleguide';
+import {
+  useConceptReferenceRanges,
+  calculateInterpretation,
+  type ObservationInterpretation,
+} from '../hooks/useConceptReferenceRanges';
 import dayjs from 'dayjs';
 
 interface VitalsTableProps {
@@ -63,15 +67,163 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
     glucose: localConcepts.glucoseUuid,
     fhr: localConcepts.fhrUuid,
   };
+  const { referenceRangeMap } = useConceptReferenceRanges(patientUuid, Object.values(vitalsConcepts));
   const { t } = useTranslation();
   const [showAll, setShowAll] = useState(false);
 
-  const { data: vitalsData, error } = useSWR<EncounterResponse>(
+  const interpretationLabels: Record<ObservationInterpretation, string> = {
+    normal: t('normal', 'Normal'),
+    high: t('high', 'High'),
+    critically_high: t('criticallyHigh', 'Critically high'),
+    off_scale_high: t('offScaleHigh', 'Off scale high'),
+    low: t('low', 'Low'),
+    critically_low: t('criticallyLow', 'Critically low'),
+    off_scale_low: t('offScaleLow', 'Off scale low'),
+  };
+
+  interface VitalCellData {
+    value: number | string | object | null;
+    interpretation?: ObservationInterpretation;
+    conceptUuid?: string;
+  }
+
+  interface VitalRowData {
+    id: string;
+    date: string;
+    bp: { systolic?: VitalCellData; diastolic?: VitalCellData };
+    pulse?: VitalCellData;
+    temperature?: VitalCellData;
+    oxygenSaturation?: VitalCellData;
+    respiratoryRate?: VitalCellData;
+    hemoglobin?: VitalCellData;
+    glucose?: VitalCellData;
+    fhr?: VitalCellData;
+  }
+
+  type VitalColumnKey = Exclude<keyof VitalRowData, 'id' | 'date'>;
+
+  const createVitalCellData = (value: number | string | object | null, conceptUuid?: string): VitalCellData => {
+    if (value === null || value === undefined) {
+      return { value: null };
+    }
+
+    const numericValue = typeof value === 'object' ? undefined : value;
+    const interpretation = conceptUuid
+      ? calculateInterpretation(numericValue, referenceRangeMap[conceptUuid])
+      : undefined;
+
+    return {
+      value,
+      interpretation,
+      conceptUuid,
+    };
+  };
+
+  const vitalColumns: Array<{ key: VitalColumnKey; label: string; conceptUuid?: string }> = [
+    { key: 'bp', label: t('bloodPressure', 'BP') },
+    { key: 'pulse', label: t('pulse', 'HR'), conceptUuid: vitalsConcepts.pulse },
+    { key: 'temperature', label: t('temperature', 'Temp'), conceptUuid: vitalsConcepts.temperature },
+    { key: 'respiratoryRate', label: t('respiratoryRate', 'RR'), conceptUuid: vitalsConcepts.respiratoryRate },
+    { key: 'oxygenSaturation', label: t('oxygenSaturation', 'O2 Sat'), conceptUuid: vitalsConcepts.oxygenSaturation },
+    { key: 'hemoglobin', label: t('hemoglobin', 'Hb'), conceptUuid: vitalsConcepts.hemoglobin },
+    { key: 'glucose', label: t('glucose', 'Glucose'), conceptUuid: vitalsConcepts.glucose },
+    { key: 'fhr', label: t('fetalHeartRate', 'FHR'), conceptUuid: vitalsConcepts.fhr },
+  ];
+
+  const renderVitalCell = (
+    cellData: VitalCellData | { systolic?: VitalCellData; diastolic?: VitalCellData } | undefined,
+  ) => {
+    if (!cellData) {
+      return <span>—</span>;
+    }
+
+    // Handle BP which is an object with systolic and diastolic
+    if ('systolic' in cellData) {
+      const bpData = cellData as { systolic?: VitalCellData; diastolic?: VitalCellData };
+      return (
+        <div style={{ display: 'flex', gap: '0', alignItems: 'center' }}>
+          {bpData.systolic && (
+            <NumericObservation
+              value={
+                bpData.systolic.value !== null && bpData.systolic.value !== undefined
+                  ? String(bpData.systolic.value)
+                  : ''
+              }
+              interpretation={bpData.systolic.interpretation}
+              conceptUuid={bpData.systolic.conceptUuid}
+              variant="cell"
+              patientUuid={patientUuid}
+            />
+          )}
+          <span style={{ margin: '0 -0.25rem' }}>/</span>
+          {bpData.diastolic && (
+            <NumericObservation
+              value={
+                bpData.diastolic.value !== null && bpData.diastolic.value !== undefined
+                  ? String(bpData.diastolic.value)
+                  : ''
+              }
+              interpretation={bpData.diastolic.interpretation}
+              conceptUuid={bpData.diastolic.conceptUuid}
+              variant="cell"
+              patientUuid={patientUuid}
+            />
+          )}
+        </div>
+      );
+    }
+
+    // Handle regular vitals
+    const vitalData = cellData as VitalCellData;
+    if (vitalData.value === null || vitalData.value === undefined) {
+      return <span>—</span>;
+    }
+
+    return (
+      <NumericObservation
+        value={String(vitalData.value)}
+        interpretation={vitalData.interpretation}
+        conceptUuid={vitalData.conceptUuid}
+        variant="cell"
+        patientUuid={patientUuid}
+      />
+    );
+  };
+
+  const createRowData = (encounter: Encounter): VitalRowData => {
+    const vitalsMap = encounter.obs.reduce(
+      (acc, obs) => {
+        acc[obs.concept.uuid] = obs.value;
+        return acc;
+      },
+      {} as Record<string, number | string | object | null>,
+    );
+
+    return {
+      id: encounter.uuid,
+      date: dayjs(encounter.encounterDatetime).format('DD/MM/YYYY HH:mm'),
+      bp: {
+        systolic: createVitalCellData(vitalsMap[vitalsConcepts.systolic], vitalsConcepts.systolic),
+        diastolic: createVitalCellData(vitalsMap[vitalsConcepts.diastolic], vitalsConcepts.diastolic),
+      },
+      pulse: createVitalCellData(vitalsMap[vitalsConcepts.pulse], vitalsConcepts.pulse),
+      temperature: createVitalCellData(vitalsMap[vitalsConcepts.temperature], vitalsConcepts.temperature),
+      oxygenSaturation: createVitalCellData(
+        vitalsMap[vitalsConcepts.oxygenSaturation],
+        vitalsConcepts.oxygenSaturation,
+      ),
+      respiratoryRate: createVitalCellData(vitalsMap[vitalsConcepts.respiratoryRate], vitalsConcepts.respiratoryRate),
+      hemoglobin: createVitalCellData(vitalsMap[vitalsConcepts.hemoglobin], vitalsConcepts.hemoglobin),
+      glucose: createVitalCellData(vitalsMap[vitalsConcepts.glucose], vitalsConcepts.glucose),
+      fhr: createVitalCellData(vitalsMap[vitalsConcepts.fhr], vitalsConcepts.fhr),
+    };
+  };
+
+  const { data: vitalsData, error } = useOpenmrsFetchAll<Encounter>(
     `${restBaseUrl}/encounter?patient=${patientUuid}&visit=${visitUuid}&order=desc&v=${customRepresentation}`,
-    (url: string) => openmrsFetch(url).then((res) => res.data),
   );
 
-  const encounters: Encounter[] = vitalsData?.results || [];
+  const encounters: Encounter[] = vitalsData || [];
 
   // Filter encounters to only include those with vitals observations
   const encountersWithVitals = encounters.filter((encounter) => {
@@ -80,33 +232,8 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
 
   // Process each encounter to extract vital signs
   const tableRows = useMemo(
-    () =>
-      encountersWithVitals.map((encounter) => {
-        const vitalsMap = encounter.obs.reduce(
-          (acc, obs) => {
-            acc[obs.concept.uuid] = obs.value;
-            return acc;
-          },
-          {} as Record<string, number | string | object | null>,
-        );
-
-        const systolic = vitalsMap[vitalsConcepts.systolic];
-        const diastolic = vitalsMap[vitalsConcepts.diastolic];
-
-        return {
-          id: encounter.uuid,
-          date: dayjs(encounter.encounterDatetime).format('DD/MM/YYYY HH:mm'),
-          bp: systolic && diastolic ? `${systolic}/${diastolic}` : '',
-          pulse: vitalsMap[vitalsConcepts.pulse] || '',
-          temperature: vitalsMap[vitalsConcepts.temperature] || '',
-          oxygenSaturation: vitalsMap[vitalsConcepts.oxygenSaturation] || '',
-          respiratoryRate: vitalsMap[vitalsConcepts.respiratoryRate] || '',
-          hemoglobin: vitalsMap[vitalsConcepts.hemoglobin] || '',
-          glucose: vitalsMap[vitalsConcepts.glucose] || '',
-          fhr: vitalsMap[vitalsConcepts.fhr] || '',
-        };
-      }),
-    [encountersWithVitals, vitalsConcepts],
+    () => encountersWithVitals.map(createRowData),
+    [encountersWithVitals, vitalsConcepts, referenceRangeMap],
   );
 
   const pageSize = 5;
@@ -124,14 +251,7 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
 
   const tableHeaders = [
     { key: 'date', header: t('date', 'Date') },
-    { key: 'bp', header: t('bloodPressure', 'BP') },
-    { key: 'pulse', header: t('pulse', 'HR') },
-    { key: 'respiratoryRate', header: t('respiratoryRate', 'RR') },
-    { key: 'temperature', header: t('temperature', 'Temp') },
-    { key: 'oxygenSaturation', header: t('oxygenSaturation', 'O2 Sat') },
-    { key: 'hemoglobin', header: t('hemoglobin', 'Hb') },
-    { key: 'glucose', header: t('glucose', 'Glucose') },
-    { key: 'fhr', header: t('fetalHeartRate', 'FHR') },
+    ...vitalColumns.map((col) => ({ key: col.key, header: col.label })),
   ];
 
   return (
@@ -150,13 +270,28 @@ const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => 
                 </TableRow>
               </TableHead>
               <TableBody>
-                {rows.map((row) => (
-                  <TableRow {...getRowProps({ row })} key={row.id}>
-                    {row.cells.map((cell) => (
-                      <TableCell key={cell.id}>{cell.value}</TableCell>
-                    ))}
-                  </TableRow>
-                ))}
+                {rows.map((row) => {
+                  const rowData = displayedRows.find((r) => r.id === row.id) as VitalRowData | undefined;
+
+                  return (
+                    <TableRow {...getRowProps({ row })} key={row.id}>
+                      {row.cells.map((cell) => {
+                        if (cell.info.header === 'date') {
+                          return <TableCell key={cell.id}>{cell.value}</TableCell>;
+                        }
+
+                        const columnKey = cell.info.header as VitalColumnKey;
+                        const cellValue = rowData?.[columnKey];
+
+                        return (
+                          <TableCell key={cell.id} style={{ padding: 0 }}>
+                            {renderVitalCell(cellValue)}
+                          </TableCell>
+                        );
+                      })}
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
           </TableContainer>

--- a/packages/esm-commons-app/src/ward-app/VitalsTable.tsx
+++ b/packages/esm-commons-app/src/ward-app/VitalsTable.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  DataTable,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@carbon/react';
+import { openmrsFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
+import useSWR from 'swr';
+import dayjs from 'dayjs';
+
+interface VitalsTableProps {
+  patientUuid: string;
+  visitUuid: string;
+}
+
+interface Observation {
+  uuid: string;
+  concept: {
+    uuid: string;
+    name: {
+      display: string;
+    };
+  };
+  value: number | string | object | null;
+}
+
+interface Encounter {
+  uuid: string;
+  display: string;
+  encounterDatetime: string;
+  obs: Observation[];
+}
+
+interface EncounterResponse {
+  results: Encounter[];
+}
+
+const customRepresentation = 'custom:(uuid,display,encounterDatetime,obs:(uuid,concept:(uuid,name:(display)),value))';
+
+const VitalsTable: React.FC<VitalsTableProps> = ({ patientUuid, visitUuid }) => {
+  const { concepts: externalConcepts } = useConfig<{ concepts: Record<string, string> }>({
+    externalModuleName: '@openmrs/esm-patient-vitals-app',
+  });
+  const { concepts: localConcepts } = useConfig<{
+    concepts: { hemoglobinUuid: string; glucoseUuid: string; fhrUuid: string };
+  }>();
+  const vitalsConcepts = {
+    systolic: externalConcepts.systolicBloodPressureUuid,
+    diastolic: externalConcepts.diastolicBloodPressureUuid,
+    pulse: externalConcepts.pulseUuid,
+    temperature: externalConcepts.temperatureUuid,
+    oxygenSaturation: externalConcepts.oxygenSaturationUuid,
+    respiratoryRate: externalConcepts.respiratoryRateUuid,
+    hemoglobin: localConcepts.hemoglobinUuid,
+    glucose: localConcepts.glucoseUuid,
+    fhr: localConcepts.fhrUuid,
+  };
+  const { t } = useTranslation();
+
+  const { data: vitalsData, error } = useSWR<EncounterResponse>(
+    `${restBaseUrl}/encounter?patient=${patientUuid}&visit=${visitUuid}&order=desc&v=${customRepresentation}`,
+    (url) => openmrsFetch(url).then((res) => res.data),
+  );
+
+  if (error) {
+    return <div>{t('errorLoadingVitals', 'Error loading vitals')}</div>;
+  }
+
+  if (!vitalsData) {
+    return <div>{t('loadingVitals', 'Loading vitals...')}</div>;
+  }
+
+  const encounters: Encounter[] = vitalsData?.results || [];
+
+  // Filter encounters to only include those with vitals observations
+  const encountersWithVitals = encounters.filter((encounter) => {
+    return encounter.obs.some((obs) => Object.values(vitalsConcepts).includes(obs.concept.uuid));
+  });
+
+  // Process each encounter to extract vital signs
+  const tableRows = encountersWithVitals.map((encounter) => {
+    const vitalsMap = encounter.obs.reduce(
+      (acc, obs) => {
+        acc[obs.concept.uuid] = obs.value;
+        return acc;
+      },
+      {} as Record<string, number | string | object | null>,
+    );
+
+    const systolic = vitalsMap[vitalsConcepts.systolic];
+    const diastolic = vitalsMap[vitalsConcepts.diastolic];
+
+    return {
+      id: encounter.uuid,
+      date: dayjs(encounter.encounterDatetime).format('DD/MM/YYYY HH:mm'),
+      bp: systolic && diastolic ? `${systolic}/${diastolic}` : '',
+      pulse: vitalsMap[vitalsConcepts.pulse] || '',
+      temperature: vitalsMap[vitalsConcepts.temperature] || '',
+      oxygenSaturation: vitalsMap[vitalsConcepts.oxygenSaturation] || '',
+      respiratoryRate: vitalsMap[vitalsConcepts.respiratoryRate] || '',
+      hemoglobin: vitalsMap[vitalsConcepts.hemoglobin] || '',
+      glucose: vitalsMap[vitalsConcepts.glucose] || '',
+      fhr: vitalsMap[vitalsConcepts.fhr] || '',
+    };
+  });
+
+  const tableHeaders = [
+    { key: 'date', header: t('date', 'Date') },
+    { key: 'bp', header: t('bloodPressure', 'BP') },
+    { key: 'pulse', header: t('pulse', 'HR') },
+    { key: 'respiratoryRate', header: t('respiratoryRate', 'RR') },
+    { key: 'temperature', header: t('temperature', 'Temp') },
+    { key: 'oxygenSaturation', header: t('oxygenSaturation', 'O2 Sat') },
+    { key: 'hemoglobin', header: t('hemoglobin', 'Hb') },
+    { key: 'glucose', header: t('glucose', 'Glucose') },
+    { key: 'fhr', header: t('fetalHeartRate', 'FHR') },
+  ];
+
+  return (
+    <DataTable headers={tableHeaders} rows={tableRows} size="sm" useZebraStyles>
+      {({ rows, headers, getTableProps, getHeaderProps, getRowProps }) => (
+        <TableContainer>
+          <Table {...getTableProps()}>
+            <TableHead>
+              <TableRow>
+                {headers.map((header) => (
+                  <TableHeader {...getHeaderProps({ header })} key={header.key}>
+                    {header.header}
+                  </TableHeader>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow {...getRowProps({ row })} key={row.id}>
+                  {row.cells.map((cell) => (
+                    <TableCell key={cell.id}>{cell.value}</TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </DataTable>
+  );
+};
+
+export default VitalsTable;

--- a/packages/esm-commons-app/src/ward-app/o2-vital-signs-workspace.component.tsx
+++ b/packages/esm-commons-app/src/ward-app/o2-vital-signs-workspace.component.tsx
@@ -2,8 +2,9 @@ import { ExtensionSlot, Workspace2 } from '@openmrs/esm-framework';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
-import O2IFrame from './o2-iframe.component';
 import type { WardPatientWorkspaceDefinition } from './types';
+import VitalsTable from './VitalsTable';
+import O2IFrame from './o2-iframe.component';
 
 const O2VitalSignsWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({ groupProps: { wardPatient } }) => {
   const { patient, visit } = wardPatient ?? {};
@@ -50,7 +51,10 @@ const O2VitalSignsWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({ group
     <Workspace2 title={t('vitalSigns', 'Vital signs')} hasUnsavedChanges={false}>
       <ExtensionSlot name="ward-workspace-patient-banner-slot" state={{ wardPatient }} />
       {iframeSrc ? (
-        <O2IFrame src={iframeSrc} elementsToHide={elementsToHide} customJavaScript={customJavaScript} />
+        <>
+          <VitalsTable patientUuid={patient.uuid} visitUuid={visit.uuid} />
+          <O2IFrame src={iframeSrc} elementsToHide={elementsToHide} customJavaScript={customJavaScript} />
+        </>
       ) : (
         <div>{t('patientHasNoActiveVisit', 'Patient has no active visit')}</div>
       )}


### PR DESCRIPTION
## Summary: Adds a table with all vitals taken during the patient's visit. One row per encounter. 
I have imported the concepts defined in the https://github.com/openmrs/openmrs-esm-patient-chart/blob/main/packages/esm-patient-vitals-app/src/config-schema.ts
and also add a config-schema for Hemoglobin, Glucose and FHR concepts which are unique to the PIH implementation.

## Screenshots

<img width="1536" height="891" alt="Screenshot 2026-04-23 at 3 55 21 PM" src="https://github.com/user-attachments/assets/cab5cd44-4129-4acd-84b5-40412ddb1585" />

Thanks @chibongho for reviewing this first draft. I still need to add concept references and trends. And also table pagination. But it would be good to get some initial feedback before I go and customize this further. Thanks!