### PR TITLE
UHM-9180 & UHM-9179: fix e2e tests

### DIFF
--- a/e2e/pages/dispensing-page.ts
+++ b/e2e/pages/dispensing-page.ts
@@ -81,7 +81,7 @@ export class DispensingPage {
   @step
   async selectLocationForActivePrescriptionTableFilter(locationName: string) {
     return test.step(`When I change the location selection filter to include "${locationName}"`, async () => {
-      await this.page.getByRole('combobox').click();
+      await this.page.getByRole('combobox').filter({ hasText: 'Filter by locations' }).click();
       await this.page.getByRole('option', { name: locationName }).click();
     });
   }
@@ -89,11 +89,15 @@ export class DispensingPage {
   // ── Assertions ────────────────────────────────────────────────────────────
 
   @step
-  async expectActivePrescriptionForPatient(patientName: string, drugName: string) {
-    return test.step(`Then I should see an active prescription for ${patientName} containing ${drugName}`, async () => {
+  async expectPrescriptionRowForPatient(
+    patientName: string,
+    drugName: string,
+    status: 'Active' | 'Completed' | 'Cancelled' | 'Expired',
+  ) {
+    return test.step(`Then I should see a prescription row for ${patientName} containing ${drugName} with status ${status}`, async () => {
       const row = this.prescriptionRow(patientName);
       await expect(row).toBeVisible();
-      await expect(row.getByRole('cell', { name: 'Active' })).toBeVisible();
+      await expect(row.getByRole('cell', { name: status })).toBeVisible();
       await expect(row.getByRole('cell', { name: new RegExp(drugName) })).toBeVisible();
     });
   }

--- a/e2e/pages/o2/forms/mch-triage-form-page.ts
+++ b/e2e/pages/o2/forms/mch-triage-form-page.ts
@@ -24,7 +24,7 @@ export class MCHTriageFormPage {
 
   @step
   async fillForm({ provider, referralFrom = 'Other', transportMethod = 'Other', disposition }: FormFields) {
-    const providerName = provider ?? process.env.E2E_DEFAULT_PROVIDER_NAME;
+    const providerName = process.env.E2E_DEFAULT_PROVIDER_NAME;
     await test.step(`Fill the MCH Triage form with provider ${provider} and disposition ${disposition}`, async () => {
       await this.o2VisitPage.page.locator('#who select').selectOption(providerName);
       await this.o2VisitPage.page.locator('#role-refer').getByLabel(referralFrom).check();

--- a/e2e/specs/dispensing/dispensing.spec.ts
+++ b/e2e/specs/dispensing/dispensing.spec.ts
@@ -40,10 +40,10 @@ test.describe('Dispensing', () => {
 
     await dispensingPage.selectLocationForActivePrescriptionTableFilter('Labour and Delivery');
     await dispensingPage.searchPrescriptions(patientIdentifier);
-    await dispensingPage.expectActivePrescriptionForPatient(patientName, 'Calcium Vitamin D3');
+    await dispensingPage.expectPrescriptionRowForPatient(patientName, 'Calcium Vitamin D3', 'Active');
   });
 
-  test('Create a paper prescription , elect to dispenseand, and verify it appears as an active prescription', async ({
+  test('Create a paper prescription , elect to dispense and, and verify it appears as an completed prescription', async ({
     page,
     adultWoman,
     adultWomanVisit,
@@ -83,6 +83,6 @@ test.describe('Dispensing', () => {
     await dispensingPage.selectLocationForActivePrescriptionTableFilter('Labour and Delivery');
     await dispensingPage.searchPrescriptions(patientIdentifier);
 
-    await dispensingPage.expectActivePrescriptionForPatient(patientName, 'Calcium Vitamin D3');
+    await dispensingPage.expectPrescriptionRowForPatient(patientName, 'Calcium Vitamin D3', 'Completed');
   });
 });


### PR DESCRIPTION
## Summary
- Make the Location filter selector in the dispensing table more robust
- Fix a dispensing test where it was not checking for the right status of the prescription
- Fix ward app test to also use provider set by E2E_DEFAULT_PROVIDER_NAME when filling out O2 forms.

## Screenshots

## Related Issue
