### PR TITLE
UHM-9335: add E2E coverage for the lab orders workflow

### DIFF
--- a/e2e/commands/location-operations.ts
+++ b/e2e/commands/location-operations.ts
@@ -4,6 +4,16 @@ import { type APIRequestContext, expect } from '@playwright/test';
  * Mostly taken from openmrs-esm-patient-management
  */
 
+/**
+ * Sets the session location.
+ *
+ * Note this also covers the browser, not just the `api` fixture: the fixture's request context
+ * inherits `use.storageState` from the Playwright config, so it loads the same JSESSIONID as the
+ * browser context and the two share one server-side session. That matters because pihapps'
+ * RequireLoginLocationFilter is mapped to every URL and redirects to loginLocation.page unless the
+ * requesting session has a location -- so calling this is what lets `page.goto` reach a legacy
+ * .page URL at all.
+ */
 export const changeLocation = async (api: APIRequestContext, locationUuid: string) => {
   const locationRes = await api.post('session', {
     data: {

--- a/e2e/commands/patient-operations.ts
+++ b/e2e/commands/patient-operations.ts
@@ -72,7 +72,7 @@ function getRandomBirthday(profile: PatientProfile): string {
 export const generateRandomPatient = async (
   api: APIRequestContext,
   profile: PatientProfile,
-  locationUuid?: string,
+  locationUuid: string,
 ): Promise<Patient> => {
   const identifierRes = await api.post(`idgen/identifiersource/${KGHEmrIdSourceUuid}/identifier`, {
     data: {},
@@ -89,7 +89,7 @@ export const generateRandomPatient = async (
         {
           identifier,
           identifierType: KGHEmrIdTypeUuid,
-          location: locationUuid || process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
+          location: locationUuid,
           preferred: true,
         },
       ],

--- a/e2e/commands/visit-operations.ts
+++ b/e2e/commands/visit-operations.ts
@@ -7,12 +7,12 @@ import { KGHVisitType } from '../core';
  * Mostly taken from openmrs-esm-patient-management
  */
 
-export const startVisit = async (api: APIRequestContext, patientId: string, locationUuid?: string): Promise<Visit> => {
+export const startVisit = async (api: APIRequestContext, patientId: string, locationUuid: string): Promise<Visit> => {
   const visitRes = await api.post('visit', {
     data: {
       startDatetime: dayjs().format('YYYY-MM-DDTHH:mm:ss.SSSZZ'),
       patient: patientId,
-      location: locationUuid || process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
+      location: locationUuid,
       visitType: KGHVisitType,
       attributes: [],
     },
@@ -22,10 +22,10 @@ export const startVisit = async (api: APIRequestContext, patientId: string, loca
   return await visitRes.json();
 };
 
-export const endVisit = async (api: APIRequestContext, uuid: string, isWardTest = false) => {
+export const endVisit = async (api: APIRequestContext, uuid: string, locationUuid: string) => {
   await api.post(`visit/${uuid}`, {
     data: {
-      location: isWardTest ? process.env.E2E_WARD_LOCATION_UUID : process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
+      location: locationUuid,
       visitType: KGHVisitType,
       stopDatetime: dayjs().format('YYYY-MM-DDTHH:mm:ss.SSSZZ'),
     },

--- a/e2e/core/constants.ts
+++ b/e2e/core/constants.ts
@@ -4,6 +4,7 @@ export const KGHLocationsUuids = {
   'Antenatal Ward': '11f5c9f9-40b8-46ad-9e7e-59473ce43246',
   KGH: '074b2ab0-716a-11eb-8aa6-0242ac110002',
   'Maternity Pharmacy': '84b9b680-786c-4388-9e7c-805614c13b5a',
+  Laboratory: '0d3704ab-17f7-4272-aa1b-9118ae51acce',
 };
 
 export const KGHEmrIdSourceUuid = '809b23e3-7162-11eb-8aa6-0242ac110002';

--- a/e2e/core/global-setup.ts
+++ b/e2e/core/global-setup.ts
@@ -21,7 +21,6 @@ async function globalSetup() {
   );
   const res = await requestContext.post(`${process.env.E2E_BASE_URL}/ws/rest/v1/session`, {
     data: {
-      sessionLocation: process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
       locale: 'en',
     },
     headers: {

--- a/e2e/core/test.ts
+++ b/e2e/core/test.ts
@@ -31,7 +31,7 @@ export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
   api: [api, { scope: 'worker' }],
   adultWoman: [
     async ({ api }, use) => {
-      const patient = await generateRandomPatient(api, 'adultWomen');
+      const patient = await generateRandomPatient(api, 'adultWomen', KGHLocationsUuids.KGH);
       await use(patient);
       await deletePatient(api, patient.uuid);
     },
@@ -41,7 +41,7 @@ export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
     async ({ api, adultWoman }, use) => {
       const visit = await startVisit(api, adultWoman.uuid, KGHLocationsUuids.KGH);
       await use(visit);
-      await endVisit(api, visit.uuid);
+      await endVisit(api, visit.uuid, KGHLocationsUuids.KGH);
     },
     { scope: 'test' },
   ],
@@ -58,7 +58,7 @@ export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
     async ({ api, newborn }, use) => {
       const visit = await startVisit(api, newborn.uuid, KGHLocationsUuids.KGH);
       await use(visit);
-      await endVisit(api, visit.uuid);
+      await endVisit(api, visit.uuid, KGHLocationsUuids.KGH);
     },
     { scope: 'test' },
   ],
@@ -75,7 +75,7 @@ export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
     async ({ api, newborn2 }, use) => {
       const visit = await startVisit(api, newborn2.uuid, KGHLocationsUuids.KGH);
       await use(visit);
-      await endVisit(api, visit.uuid);
+      await endVisit(api, visit.uuid, KGHLocationsUuids.KGH);
     },
     { scope: 'test' },
   ],

--- a/e2e/pages/o2/labs/add-lab-orders-page.ts
+++ b/e2e/pages/o2/labs/add-lab-orders-page.ts
@@ -1,0 +1,105 @@
+import { expect, type Page } from '@playwright/test';
+import { type Patient } from '@openmrs/esm-framework';
+import { step, test } from '../../../core';
+
+/**
+ * The "Add Lab orders" page for a single patient (pihapps labOrder.page).
+ *
+ * Every test category is rendered into the DOM at once and only the active one is shown, so the
+ * lab test buttons are looked up inside the visible category pane. The first category
+ * (Haematology) activates itself on load.
+ */
+export class O2AddLabOrdersPage {
+  private constructor(readonly page: Page) {}
+
+  readonly saveButton = () => this.page.locator('#draft-save-button');
+  readonly discardAllButton = () => this.page.locator('#draft-discard-all');
+  readonly returnButton = () => this.page.locator('#cancel-button');
+  readonly draftOrderCount = () => this.page.locator('#num-draft-orders');
+  readonly draftOrders = () => this.page.locator('#draft-list-container li.draft-list');
+
+  categoryTab(categoryName: string) {
+    return this.page.locator('a.category-link').filter({ hasText: categoryName });
+  }
+
+  /**
+   * Panel buttons wrap a hover tooltip listing their member tests, so the button's text is more
+   * than just its label -- hasText (substring) handles that, where an exact-name role lookup
+   * would not. Scoped to the visible pane so that a name reused in another category can't match.
+   */
+  labTestButton(labTestName: string) {
+    return this.page.locator('.lab-selection-form:visible button.lab-tests-btn').filter({ hasText: labTestName });
+  }
+
+  draftOrder(labTestName: string) {
+    return this.draftOrders().filter({ hasText: labTestName });
+  }
+
+  @step
+  static async open(page: Page, patient: Patient, returnUrl?: string) {
+    return test.step(`When I navigate to the add lab orders page for patient ${patient.uuid}`, async () => {
+      const addLabOrdersPage = new O2AddLabOrdersPage(page);
+      const returnUrlParam = returnUrl ? `&returnUrl=${encodeURIComponent(returnUrl)}` : '';
+      await page.goto(
+        `${process.env.E2E_BASE_URL}/pihapps/labs/labOrder.page?patient=${patient.uuid}${returnUrlParam}`,
+      );
+      await expect(addLabOrdersPage.saveButton()).toBeVisible();
+      return addLabOrdersPage;
+    });
+  }
+
+  /** For when we already navigated here (e.g. by selecting a patient from the search page). */
+  @step
+  static async at(page: Page) {
+    return test.step('When I land on the add lab orders page', async () => {
+      const addLabOrdersPage = new O2AddLabOrdersPage(page);
+      await expect(addLabOrdersPage.saveButton()).toBeVisible();
+      return addLabOrdersPage;
+    });
+  }
+
+  @step
+  async selectCategory(categoryName: string) {
+    return test.step(`When I select the "${categoryName}" lab category`, async () => {
+      await this.categoryTab(categoryName).click();
+      await expect(this.categoryTab(categoryName)).toHaveClass(/active-category/);
+    });
+  }
+
+  @step
+  async selectLabTest(labTestName: string) {
+    return test.step(`When I select the "${labTestName}" lab test`, async () => {
+      await this.labTestButton(labTestName).click();
+      await expect(this.draftOrder(labTestName)).toBeVisible();
+    });
+  }
+
+  /**
+   * Saves the drafted orders. On success the page immediately redirects to its returnUrl, which
+   * tears down the "Order Successfully Created" toast before it can reliably be asserted on -- so
+   * leaving this page is what we wait for instead.
+   */
+  @step
+  async save() {
+    return test.step('When I save the lab orders', async () => {
+      await this.saveButton().click();
+      await this.page.waitForURL((url) => !url.pathname.endsWith('labOrder.page'));
+    });
+  }
+
+  @step
+  async expectDraftOrderCount(count: number) {
+    return test.step(`Then I should see ${count} draft order(s)`, async () => {
+      await expect(this.draftOrderCount()).toHaveText(String(count));
+      await expect(this.draftOrders()).toHaveCount(count);
+    });
+  }
+
+  @step
+  async expectOrdersSaved() {
+    return test.step('Then the orders should have been saved', async () => {
+      await expect(this.page).not.toHaveURL(/labOrder\.page/);
+      await expect(this.saveButton()).toHaveCount(0);
+    });
+  }
+}

--- a/e2e/pages/o2/labs/add-lab-orders-search-page.ts
+++ b/e2e/pages/o2/labs/add-lab-orders-search-page.ts
@@ -1,0 +1,51 @@
+import { expect, type Page } from '@playwright/test';
+import { type Patient } from '@openmrs/esm-framework';
+import { getPatientIdentifierStr } from '../../../commands';
+import { step, test } from '../../../core';
+import { O2AddLabOrdersPage } from './add-lab-orders-page';
+
+/**
+ * The find-patient screen that fronts lab ordering
+ * (coreapps findPatient.page for the pih.app.labs.ordering app).
+ */
+export class O2AddLabOrdersSearchPage {
+  private constructor(readonly page: Page) {}
+
+  readonly searchByIdOrNameField = () => this.page.getByPlaceholder('Search by ID or Name');
+  readonly searchResultsTable = () => this.page.locator('#patient-search-results-table');
+
+  searchResultRow(patientIdentifier: string) {
+    return this.searchResultsTable().locator('tbody tr').filter({ hasText: patientIdentifier });
+  }
+
+  @step
+  static async open(page: Page) {
+    return test.step('When I navigate to the add lab orders patient search page', async () => {
+      const searchPage = new O2AddLabOrdersSearchPage(page);
+      await page.goto(`${process.env.E2E_BASE_URL}/coreapps/findpatient/findPatient.page?app=pih.app.labs.ordering`);
+      await expect(searchPage.searchByIdOrNameField()).toBeVisible();
+      return searchPage;
+    });
+  }
+
+  /**
+   * Searches by EMR ID and lands on the add lab orders page for that patient.
+   *
+   * Typing alone issues no request -- the widget searches on Enter. And on an exact identifier
+   * match it does not populate the results table at all: it looks the patient up
+   * (GET /ws/rest/v1/patient?identifier=...) and navigates straight to the app's afterSelectedUrl.
+   * So there is no row to click in this flow; `searchResultRow` is there for a name search, which
+   * does render rows.
+   */
+  @step
+  async searchForPatientByIdentifier(patient: Patient) {
+    const patientIdentifier = getPatientIdentifierStr(patient);
+    await test.step(`When I search for patient "${patientIdentifier}" by EMR ID`, async () => {
+      await this.searchByIdOrNameField().click();
+      await this.searchByIdOrNameField().pressSequentially(patientIdentifier);
+      await this.searchByIdOrNameField().press('Enter');
+      await expect(this.page).toHaveURL(/labOrder\.page/);
+    });
+    return O2AddLabOrdersPage.at(this.page);
+  }
+}

--- a/e2e/pages/o2/labs/index.ts
+++ b/e2e/pages/o2/labs/index.ts
@@ -1,0 +1,5 @@
+export * from './add-lab-orders-page';
+export * from './add-lab-orders-search-page';
+export * from './lab-orders-page';
+export * from './patient-lab-orders-page';
+export * from './patient-lab-results-page';

--- a/e2e/pages/o2/labs/lab-orders-page.ts
+++ b/e2e/pages/o2/labs/lab-orders-page.ts
@@ -1,0 +1,405 @@
+import { expect, type Page } from '@playwright/test';
+import { type Patient } from '@openmrs/esm-framework';
+import { getPatientIdentifierStr } from '../../../commands';
+import { step, test } from '../../../core';
+
+/** Status as rendered in the order table's Status column. */
+export type LabOrderStatus = 'Ordered' | 'Collected' | 'Reported' | 'Not Performed' | 'Canceled' | 'Expired';
+
+/** Aggregate status badge rendered against a patient group row. */
+export type LabPatientStatus =
+  | 'All Ordered'
+  | 'All Collected'
+  | 'All Reported'
+  | 'All Not Performed'
+  | 'All Canceled'
+  | 'All Expired'
+  | 'Mixed';
+
+/** The Lab Status buttons offered by the record-results form. */
+export type LabFulfillerStatus = 'In Progress' | 'Completed' | 'Not performed';
+
+/**
+ * Every fulfillment status the list can filter on. The page defaults to showing only Ordered +
+ * Collected, and it re-queries after every save -- so without widening this, a row that reaches a
+ * terminal status silently drops out of the table.
+ */
+const ALL_FULFILLMENT_STATUSES = [
+  'AWAITING_FULFILLMENT',
+  'IN_FULFILLMENT',
+  'COMPLETED_FULFILLMENT',
+  'UNABLE_TO_COMPLETE_FULFILLMENT',
+  'EXPIRED_BEFORE_FULFILLMENT',
+  'CANCELLED_BEFORE_FULFILLMENT',
+];
+
+/**
+ * The lab orders worklist (pihapps labOrderList.page).
+ *
+ * This is a single page holding four sibling sections that are shown and hidden with jQuery; the
+ * URL never changes as you move between them, so assertions key on section visibility rather than
+ * on page.url(). The three data-entry sections are modelled as nested classes.
+ */
+export class O2LabOrdersPage {
+  private constructor(readonly page: Page) {}
+
+  // ── Sections ──────────────────────────────────────────────────────────────
+  readonly viewOrdersSection = () => this.page.locator('#view-orders-section');
+  readonly specimenCollectionSection = () => this.page.locator('#edit-specimen-encounter-section');
+  readonly recordResultsSection = () => this.page.locator('#record-lab-results-section');
+  readonly notPerformedSection = () => this.page.locator('#edit-reason-not-performed-section');
+
+  // ── List view ─────────────────────────────────────────────────────────────
+  readonly groupByOrderButton = () => this.page.locator('#group-by-order-btn');
+  readonly groupByPatientButton = () => this.page.locator('#group-by-patient-btn');
+  readonly addLabOrdersLink = () => this.page.getByRole('link', { name: 'Add Lab orders' });
+  readonly ordersTable = () => this.page.locator('#orders-table');
+  readonly patientsTable = () => this.page.locator('#patients-table');
+  readonly patientFilter = () => this.page.locator('#patient-filter-display');
+
+  /**
+   * A row in "Group by: Order" mode. Rows carry no id or data attribute, so they are found by the
+   * lab test name in the Lab Test column (9th cell).
+   */
+  orderRow(labTestName: string) {
+    return this.ordersTable()
+      .locator('tbody tr')
+      .filter({ has: this.page.locator('td:nth-child(9)', { hasText: labTestName }) });
+  }
+
+  orderRowStatus(labTestName: string) {
+    return this.orderRow(labTestName).locator('td:nth-child(8)');
+  }
+
+  patientGroupRow(patient: Patient) {
+    return this.patientsTable().locator(`tr.patient-group-row[data-patient-uuid="${patient.uuid}"]`);
+  }
+
+  patientSubRow(patient: Patient, labTestName: string) {
+    return this.patientsTable()
+      .locator(`tr.patient-sub-row.patient-sub-row-${patient.uuid}`)
+      .filter({ hasText: labTestName });
+  }
+
+  @step
+  static async open(page: Page) {
+    return test.step('When I navigate to the lab orders page', async () => {
+      const labOrdersPage = new O2LabOrdersPage(page);
+      // Deep-link every status: the page reads repeated `status` params on load, and the default
+      // (Ordered + Collected) would hide any order that reached a terminal status.
+      const statusParams = ALL_FULFILLMENT_STATUSES.map((status) => `status=${status}`).join('&');
+      await page.goto(`${process.env.E2E_BASE_URL}/pihapps/labs/labOrderList.page?${statusParams}`);
+      await expect(labOrdersPage.viewOrdersSection()).toBeVisible();
+      await labOrdersPage.waitForOrdersTable();
+      return labOrdersPage;
+    });
+  }
+
+  /**
+   * The table is cleared and repopulated with a spinner placeholder row on every refresh, so wait
+   * for rows to exist and then for the spinners to be gone.
+   */
+  private async waitForOrdersTable() {
+    await expect(this.ordersTable().locator('tbody tr')).not.toHaveCount(0);
+    await expect(this.ordersTable().locator('tbody i.icon-spinner')).toHaveCount(0);
+  }
+
+  private async waitForPatientsTable() {
+    await expect(this.patientsTable().locator('tbody tr')).not.toHaveCount(0);
+    await expect(this.patientsTable().locator('tbody i.icon-spinner')).toHaveCount(0);
+  }
+
+  /**
+   * Narrows the (global, paginated) list to one patient. Driven through the jQuery UI autocomplete
+   * the way a user would: typing character by character, since fill() would not trigger it.
+   */
+  @step
+  async filterByPatient(patient: Patient) {
+    const patientIdentifier = getPatientIdentifierStr(patient);
+    return test.step(`When I filter the lab orders by patient "${patientIdentifier}"`, async () => {
+      await this.patientFilter().click();
+      await this.patientFilter().pressSequentially(patientIdentifier);
+      const suggestion = this.page.locator('ul.ui-autocomplete li').first();
+      await suggestion.waitFor({ state: 'visible' });
+      await suggestion.click();
+      await this.waitForOrdersTable();
+    });
+  }
+
+  @step
+  async switchToGroupByPatient() {
+    return test.step('When I switch to "Group by: Patient"', async () => {
+      await this.groupByPatientButton().click();
+      await expect(this.groupByPatientButton()).toHaveClass(/active/);
+      await this.waitForPatientsTable();
+    });
+  }
+
+  @step
+  async switchToGroupByOrder() {
+    return test.step('When I switch to "Group by: Order"', async () => {
+      await this.groupByOrderButton().click();
+      await expect(this.groupByOrderButton()).toHaveClass(/active/);
+      await this.waitForOrdersTable();
+    });
+  }
+
+  @step
+  async expandPatientRow(patient: Patient) {
+    return test.step('When I expand the patient row', async () => {
+      await this.patientGroupRow(patient).locator('td:nth-child(1) span').click();
+      await expect(this.patientsTable().locator(`tr.patient-sub-row-${patient.uuid}`).first()).toBeVisible();
+    });
+  }
+
+  // ── Row actions ───────────────────────────────────────────────────────────
+  // These are bare <i> icons with no role and no accessible name beyond `title`.
+
+  @step
+  async collectSpecimen(labTestName: string) {
+    await test.step(`When I collect the specimen for "${labTestName}"`, async () => {
+      await this.orderRow(labTestName).locator('i.collect-specimen-action').click();
+      await expect(this.specimenCollectionSection()).toBeVisible();
+    });
+    return new O2LabOrdersPage.SpecimenCollectionForm(this.page, this);
+  }
+
+  /** Bulk specimen collection: the only entry point is the patient group row in patient mode. */
+  @step
+  async collectSpecimenForPatient(patient: Patient) {
+    await test.step("When I collect specimens for all of the patient's orders", async () => {
+      await this.patientGroupRow(patient).locator('i.collect-specimen-group-action').click();
+      await expect(this.specimenCollectionSection()).toBeVisible();
+    });
+    return new O2LabOrdersPage.SpecimenCollectionForm(this.page, this);
+  }
+
+  @step
+  async recordResults(labTestName: string) {
+    await test.step(`When I open the results form for "${labTestName}"`, async () => {
+      await this.orderRow(labTestName).locator('i.enter-results-action').click();
+      await expect(this.recordResultsSection()).toBeVisible();
+    });
+    return new O2LabOrdersPage.RecordResultsForm(this.page, this);
+  }
+
+  @step
+  async markAsNotCollected(labTestName: string) {
+    await test.step(`When I mark "${labTestName}" as not collected`, async () => {
+      await this.orderRow(labTestName).locator('i.mark-not-performed-action').click();
+      await expect(this.notPerformedSection()).toBeVisible();
+    });
+    return new O2LabOrdersPage.NotPerformedForm(this.page, this);
+  }
+
+  // ── Assertions ────────────────────────────────────────────────────────────
+
+  @step
+  async expectOrderCount(count: number) {
+    return test.step(`Then I should see ${count} lab order(s) in the table`, async () => {
+      await expect(this.ordersTable().locator('tbody tr')).toHaveCount(count);
+    });
+  }
+
+  @step
+  async expectOrderStatus(labTestName: string, status: LabOrderStatus) {
+    return test.step(`Then "${labTestName}" should have status "${status}"`, async () => {
+      await expect(this.orderRow(labTestName)).toBeVisible();
+      await expect(this.orderRowStatus(labTestName)).toContainText(status);
+    });
+  }
+
+  @step
+  async expectOrderStatuses(statusesByLabTest: Record<string, LabOrderStatus>) {
+    return test.step('Then I should see the expected order statuses', async () => {
+      for (const [labTestName, status] of Object.entries(statusesByLabTest)) {
+        await expect(this.orderRowStatus(labTestName)).toContainText(status);
+      }
+    });
+  }
+
+  @step
+  async expectPatientStatus(patient: Patient, status: LabPatientStatus) {
+    return test.step(`Then the patient's orders should show status "${status}"`, async () => {
+      await expect(this.patientGroupRow(patient).locator('td:nth-child(3)')).toHaveText(status);
+    });
+  }
+
+  @step
+  async expectPatientSubRowStatus(patient: Patient, labTestName: string, status: LabOrderStatus) {
+    return test.step(`Then "${labTestName}" should show status "${status}" under the patient`, async () => {
+      await expect(this.patientSubRow(patient, labTestName).locator('td:nth-child(2)')).toContainText(status);
+    });
+  }
+
+  @step
+  async expectBackOnOrdersList() {
+    return test.step('Then I should be back on the lab orders list', async () => {
+      await expect(this.viewOrdersSection()).toBeVisible();
+      await expect(this.specimenCollectionSection()).toBeHidden();
+      await expect(this.recordResultsSection()).toBeHidden();
+      await expect(this.notPerformedSection()).toBeHidden();
+    });
+  }
+
+  // ── Sub-view: specimen collection ─────────────────────────────────────────
+
+  static SpecimenCollectionForm = class SpecimenCollectionForm {
+    constructor(
+      private page: Page,
+      readonly labOrdersPage: O2LabOrdersPage,
+    ) {}
+
+    private readonly section = () => this.page.locator('#specimen-encounter-section');
+
+    readonly labIdField = () => this.page.locator('#specimen-encounter-section-lab-id-input');
+    readonly specimenCollectionLocation = () =>
+      this.page.locator('#specimen-encounter-section-specimen-location-picker');
+    readonly saveButton = () => this.section().locator('button.confirm.action-button');
+    readonly cancelButton = () => this.section().locator('button.cancel.action-button');
+    readonly errors = () => this.section().locator('.errors-section');
+
+    /** Accessible name comes from aria-label, which is the lab test's display string. */
+    orderCheckbox(labTestName: string) {
+      return this.section().getByRole('checkbox', { name: labTestName });
+    }
+
+    @step
+    async waitUntilReady() {
+      await expect(this.section().locator('.form-content-section')).toBeVisible();
+      await expect(this.labIdField()).toBeVisible();
+    }
+
+    /**
+     * Specimen collection date, received date and collection location are all either pre-filled or
+     * optional, so the Lab ID is the only field the tests need to set.
+     */
+    @step
+    async fillLabId(labId: string) {
+      return test.step(`When I enter the lab ID "${labId}"`, async () => {
+        await this.labIdField().fill(labId);
+      });
+    }
+
+    @step
+    async uncheckOrder(labTestName: string) {
+      return test.step(`When I deselect "${labTestName}" from the specimen collection`, async () => {
+        await this.orderCheckbox(labTestName).uncheck();
+      });
+    }
+
+    @step
+    async expectOrderSelected(labTestName: string, selected: boolean) {
+      return test.step(`Then "${labTestName}" should be ${selected ? 'selected' : 'deselected'}`, async () => {
+        if (selected) {
+          await expect(this.orderCheckbox(labTestName)).toBeChecked();
+        } else {
+          await expect(this.orderCheckbox(labTestName)).not.toBeChecked();
+        }
+      });
+    }
+
+    @step
+    async save() {
+      await test.step('When I save the specimen collection', async () => {
+        await this.saveButton().click();
+        await expect(this.labOrdersPage.specimenCollectionSection()).toBeHidden();
+      });
+      return this.labOrdersPage;
+    }
+  };
+
+  // ── Sub-view: record results ──────────────────────────────────────────────
+
+  static RecordResultsForm = class RecordResultsForm {
+    constructor(
+      private page: Page,
+      readonly labOrdersPage: O2LabOrdersPage,
+    ) {}
+
+    private readonly section = () => this.page.locator('#lab-results-section');
+
+    readonly saveButton = () => this.section().locator('button.confirm.action-button');
+    readonly cancelButton = () => this.section().locator('button.cancel.action-button');
+    readonly reasonNotPerformed = () => this.section().locator('.result-field.reason-not-performed select');
+    readonly errors = () => this.section().locator('.errors-section');
+
+    /**
+     * The Lab Status control is a hidden <select> rendered as a button group, so selectOption()
+     * cannot drive it -- the buttons have to be clicked.
+     */
+    statusButton(status: LabFulfillerStatus) {
+      return this.section().locator('.fulfiller-status .btn-group.select-buttons button').filter({ hasText: status });
+    }
+
+    @step
+    async waitUntilReady() {
+      // Save/Cancel live inside this section and don't exist until two chained GETs resolve.
+      await expect(this.section().locator('.result-entry-section')).toBeVisible();
+      await expect(this.saveButton()).toBeVisible();
+    }
+
+    /** Selecting a status clears the other status section's inputs, so do this first. */
+    @step
+    async selectStatus(status: LabFulfillerStatus) {
+      return test.step(`When I set the lab status to "${status}"`, async () => {
+        await this.statusButton(status).click();
+        await expect(this.statusButton(status)).toHaveClass(/active/);
+      });
+    }
+
+    @step
+    async selectReasonNotPerformed(reason: string) {
+      return test.step(`When I select the reason "${reason}"`, async () => {
+        await this.reasonNotPerformed().selectOption({ label: reason });
+      });
+    }
+
+    @step
+    async save() {
+      await test.step('When I save the lab results', async () => {
+        await this.saveButton().click();
+        await expect(this.labOrdersPage.recordResultsSection()).toBeHidden();
+      });
+      return this.labOrdersPage;
+    }
+  };
+
+  // ── Sub-view: mark as not collected ───────────────────────────────────────
+
+  static NotPerformedForm = class NotPerformedForm {
+    constructor(
+      private page: Page,
+      readonly labOrdersPage: O2LabOrdersPage,
+    ) {}
+
+    private readonly section = () => this.page.locator('#reason-not-performed-section');
+
+    readonly reasonSelect = () => this.section().locator('.obs-field-remove-reason select');
+    readonly saveButton = () => this.section().locator('button.confirm.action-button');
+    readonly cancelButton = () => this.section().locator('button.cancel.action-button');
+    readonly errors = () => this.section().locator('.errors-section');
+
+    @step
+    async waitUntilReady() {
+      await expect(this.section().locator('.form-content-section')).toBeVisible();
+      await expect(this.reasonSelect()).toBeVisible();
+    }
+
+    @step
+    async selectReason(reason: string) {
+      return test.step(`When I select the reason "${reason}"`, async () => {
+        await this.reasonSelect().selectOption({ label: reason });
+      });
+    }
+
+    @step
+    async save() {
+      await test.step('When I save the not-collected reason', async () => {
+        await this.saveButton().click();
+        await expect(this.labOrdersPage.notPerformedSection()).toBeHidden();
+      });
+      return this.labOrdersPage;
+    }
+  };
+}

--- a/e2e/pages/o2/labs/patient-lab-orders-page.ts
+++ b/e2e/pages/o2/labs/patient-lab-orders-page.ts
@@ -1,0 +1,114 @@
+import { expect, type Page } from '@playwright/test';
+import { type Patient } from '@openmrs/esm-framework';
+import { step, test } from '../../../core';
+import { type LabOrderStatus } from './lab-orders-page';
+
+/**
+ * A single patient's lab orders (pihapps labOrders.page).
+ *
+ * Note the page's own post-cancel redirect is broken -- it appends a stray ">" to the URL -- so
+ * after cancelling an order, assert on the success message and then re-open the page (or the lab
+ * orders worklist) rather than trusting wherever the redirect lands.
+ */
+export class O2PatientLabOrdersPage {
+  private constructor(readonly page: Page) {}
+
+  readonly orderStatusFilter = () => this.page.locator('#orderFulfillmentStatus-filter');
+  readonly labTestFilter = () => this.page.locator('#testConcept-filter');
+  readonly ordersTable = () => this.page.locator('#orders-table');
+  readonly addLabOrdersButton = () => this.page.getByRole('button', { name: 'Add Lab orders' });
+
+  // Discontinue confirmation dialog
+  readonly discontinueDialog = () => this.page.locator('#discontinue-order-dialog');
+  readonly discontinueReasonField = () => this.page.locator('#discontinue-reason-field');
+  readonly discontinueConfirmButton = () => this.discontinueDialog().locator('button.confirm');
+  readonly discontinueCancelButton = () => this.discontinueDialog().locator('button.cancel');
+
+  /** Rows carry no attributes; the Lab Test column is the 3rd cell on this page. */
+  orderRow(labTestName: string) {
+    return this.ordersTable()
+      .locator('tbody tr')
+      .filter({ has: this.page.locator('td:nth-child(3)', { hasText: labTestName }) });
+  }
+
+  orderRowStatus(labTestName: string) {
+    return this.orderRow(labTestName).locator('td:nth-child(5)');
+  }
+
+  /** The cancel "X" -- an icon-font glyph inside an anchor, with no accessible name. */
+  cancelOrderButton(labTestName: string) {
+    return this.orderRow(labTestName).locator('span.order-actions-btn a');
+  }
+
+  @step
+  static async open(page: Page, patient: Patient) {
+    return test.step(`When I navigate to the lab orders page for patient ${patient.uuid}`, async () => {
+      const patientLabOrdersPage = new O2PatientLabOrdersPage(page);
+      await page.goto(`${process.env.E2E_BASE_URL}/pihapps/labs/labOrders.page?patient=${patient.uuid}`);
+      await patientLabOrdersPage.waitForOrdersTable();
+      return patientLabOrdersPage;
+    });
+  }
+
+  private async waitForOrdersTable() {
+    await expect(this.ordersTable().locator('tbody tr')).not.toHaveCount(0);
+    await expect(this.ordersTable().locator('tbody i.icon-spinner')).toHaveCount(0);
+  }
+
+  @step
+  async filterByOrderStatus(status: LabOrderStatus) {
+    return test.step(`When I filter by order status "${status}"`, async () => {
+      // Options are appended by JS after load, so wait for them before selecting.
+      await expect(this.orderStatusFilter().locator('option')).not.toHaveCount(0);
+      await this.orderStatusFilter().selectOption({ label: status });
+      await this.waitForOrdersTable();
+    });
+  }
+
+  @step
+  async filterByLabTest(labTestName: string) {
+    return test.step(`When I filter by lab test "${labTestName}"`, async () => {
+      // A 2nd option means the config-driven optgroups loaded; not.toHaveCount(1) would also pass
+      // with zero options, which is the very case this guards against.
+      await expect(this.labTestFilter().locator('option').nth(1)).toBeAttached();
+      await this.labTestFilter().selectOption({ label: labTestName });
+      await this.waitForOrdersTable();
+    });
+  }
+
+  /**
+   * Clicks the "X" for an order and confirms the discontinue dialog.
+   *
+   * The page's own success handler shows a toast and then redirects to a malformed URL (it appends
+   * a stray ">" to the patient id), so neither the toast nor the resulting page is dependable.
+   * We wait on the discontinue request itself, then callers should navigate somewhere real.
+   */
+  @step
+  async cancelOrder(labTestName: string, reason = 'Cancelled by E2E test') {
+    return test.step(`When I cancel the "${labTestName}" order`, async () => {
+      await this.cancelOrderButton(labTestName).click();
+      await expect(this.discontinueDialog()).toBeVisible();
+      await this.discontinueReasonField().fill(reason);
+
+      const discontinueResponse = this.page.waitForResponse(
+        (response) => response.url().includes('/ws/rest/v1/encounter') && response.request().method() === 'POST',
+      );
+      await this.discontinueConfirmButton().click();
+      expect((await discontinueResponse).ok()).toBeTruthy();
+    });
+  }
+
+  @step
+  async expectOrderStatus(labTestName: string, status: LabOrderStatus) {
+    return test.step(`Then "${labTestName}" should have status "${status}"`, async () => {
+      await expect(this.orderRowStatus(labTestName)).toContainText(status);
+    });
+  }
+
+  @step
+  async expectNoCancelActionFor(labTestName: string) {
+    return test.step(`Then "${labTestName}" should no longer offer a cancel action`, async () => {
+      await expect(this.cancelOrderButton(labTestName)).toHaveCount(0);
+    });
+  }
+}

--- a/e2e/pages/o2/labs/patient-lab-results-page.ts
+++ b/e2e/pages/o2/labs/patient-lab-results-page.ts
@@ -1,0 +1,42 @@
+import { expect, type Page } from '@playwright/test';
+import { type Patient } from '@openmrs/esm-framework';
+import { step, test } from '../../../core';
+
+/** A single patient's lab results (pihapps patientLabResults.page). */
+export class O2PatientLabResultsPage {
+  private constructor(readonly page: Page) {}
+
+  readonly resultsSection = () => this.page.locator('#patient-lab-results-section');
+  readonly resultsTable = () => this.page.locator('#results-table');
+  readonly categoryFilter = () => this.page.locator('#category-filter');
+  readonly panelFilter = () => this.page.locator('#panel-filter');
+  readonly labTestFilter = () => this.page.locator('#testConcept-filter');
+  readonly groupByDateCheckbox = () => this.page.locator('#groupByDate-filter');
+  readonly clearFiltersLink = () => this.page.locator('#clear-all-filters');
+  readonly returnButton = () => this.page.locator('#cancel-button');
+
+  resultRow(labTestName: string) {
+    return this.resultsTable().locator('tbody tr').filter({ hasText: labTestName });
+  }
+
+  @step
+  static async open(page: Page, patient: Patient) {
+    return test.step(`When I navigate to the lab results page for patient ${patient.uuid}`, async () => {
+      const patientLabResultsPage = new O2PatientLabResultsPage(page);
+      await page.goto(`${process.env.E2E_BASE_URL}/pihapps/labs/patientLabResults.page?patient=${patient.uuid}`);
+      await expect(patientLabResultsPage.resultsSection()).toBeVisible();
+      // Filter options are only populated once the config request resolves. Asserting a 2nd option
+      // is attached means "more than just the blank one" -- unlike not.toHaveCount(1), which would
+      // also be satisfied by zero options, i.e. by the config never having loaded.
+      await expect(patientLabResultsPage.categoryFilter().locator('option').nth(1)).toBeAttached();
+      return patientLabResultsPage;
+    });
+  }
+
+  @step
+  async expectResultRow(labTestName: string) {
+    return test.step(`Then I should see a result row for "${labTestName}"`, async () => {
+      await expect(this.resultRow(labTestName)).toBeVisible();
+    });
+  }
+}

--- a/e2e/pages/o2/patient-chart-page.ts
+++ b/e2e/pages/o2/patient-chart-page.ts
@@ -1,0 +1,53 @@
+import { expect, type Page } from '@playwright/test';
+import { type Patient } from '@openmrs/esm-framework';
+import { step, test } from '../../core';
+
+/**
+ * The legacy O2 clinician-facing patient chart.
+ *
+ * The "General Actions" links are app-framework extensions, and the anchor's id is the extension
+ * id verbatim -- hence the attribute selectors rather than getByRole.
+ */
+export class O2PatientChartPage {
+  private constructor(readonly page: Page) {}
+
+  readonly labOrdersLink = () => this.page.locator('a[id="orderentryowa.orderLabs"]');
+  readonly viewLabResultsLink = () => this.page.locator('a[id="labworkflowowa.viewLabs"]');
+
+  @step
+  static async open(page: Page, patient: Patient) {
+    return test.step(`When I navigate to the patient chart for patient ${patient.uuid}`, async () => {
+      const patientChartPage = new O2PatientChartPage(page);
+      await page.goto(`${process.env.E2E_BASE_URL}/coreapps/clinicianfacing/patient.page?patientId=${patient.uuid}`);
+      return patientChartPage;
+    });
+  }
+
+  @step
+  async openLabOrders() {
+    return test.step('When I click the "Lab Orders" link', async () => {
+      await this.labOrdersLink().click();
+      // The href picks up a doubled slash and an appended returnUrl, so match loosely.
+      await expect(this.page).toHaveURL(/labOrders\.page/);
+    });
+  }
+
+  @step
+  async openLabResults() {
+    return test.step('When I click the "View Lab Results" link', async () => {
+      await this.viewLabResultsLink().click();
+      // Routes via pihcore/router/labRouter.page, which redirects when pihcore.usePihAppsLabs is on.
+      await expect(this.page).toHaveURL(/patientLabResults\.page|labworkflow/);
+    });
+  }
+
+  @step
+  async expectLabLinksVisible() {
+    return test.step('Then I should see the lab orders and lab results links', async () => {
+      await expect(this.labOrdersLink()).toBeVisible();
+      await expect(this.labOrdersLink()).toHaveText('Lab Orders');
+      await expect(this.viewLabResultsLink()).toBeVisible();
+      await expect(this.viewLabResultsLink()).toHaveText('View Lab Results');
+    });
+  }
+}

--- a/e2e/specs/labs/lab-orders.spec.ts
+++ b/e2e/specs/labs/lab-orders.spec.ts
@@ -1,0 +1,148 @@
+import { changeLocation } from '../../commands';
+import { KGHLocationsUuids, test } from '../../core';
+import { O2AddLabOrdersPage, O2LabOrdersPage, O2PatientLabOrdersPage } from '../../pages/o2/labs';
+
+const TEST_CBC_3_PART_DIFF = 'CBC 3-part diff';
+const TEST_CBC_5_PART_DIFF = 'CBC 5-part diff';
+const TEST_COAGULATION_PROFILE = 'Coagulation profile';
+const TEST_LIPID_PROFILE = 'Lipid profile';
+const TEST_LIVER_FUNCTION = 'Liver function';
+
+// Reasons come from the "Reason lab procedure not performed" concept's answers.
+const NOT_PERFORMED_REASON = 'Insufficient sample';
+const NOT_COLLECTED_REASON = 'Specimen not available';
+
+test.describe('Lab Orders', () => {
+  test.beforeEach(async ({ api }) => {
+    // pihapps' RequireLoginLocationFilter redirects every URL to loginLocation.page until the
+    // session has a location, so this is a precondition for reaching the lab pages at all.
+    await changeLocation(api, KGHLocationsUuids.Laboratory);
+  });
+
+  test('Order a lab test, collect the specimen, then record the result as completed', async ({ page, adultWoman }) => {
+    const addLabOrdersPage = await O2AddLabOrdersPage.open(page, adultWoman);
+    await addLabOrdersPage.selectCategory('Haematology');
+    await addLabOrdersPage.selectLabTest(TEST_CBC_3_PART_DIFF);
+    await addLabOrdersPage.expectDraftOrderCount(1);
+    await addLabOrdersPage.save();
+    await addLabOrdersPage.expectOrdersSaved();
+
+    const labOrdersPage = await O2LabOrdersPage.open(page);
+    await labOrdersPage.filterByPatient(adultWoman);
+    await labOrdersPage.expectOrderCount(1);
+    await labOrdersPage.expectOrderStatus(TEST_CBC_3_PART_DIFF, 'Ordered');
+
+    const specimenCollectionForm = await labOrdersPage.collectSpecimen(TEST_CBC_3_PART_DIFF);
+    await specimenCollectionForm.waitUntilReady();
+    await specimenCollectionForm.fillLabId(`E2E Test ${Date.now()}`);
+    await specimenCollectionForm.save();
+    await labOrdersPage.expectBackOnOrdersList();
+    await labOrdersPage.expectOrderStatus(TEST_CBC_3_PART_DIFF, 'Collected');
+
+    const recordResultsForm = await labOrdersPage.recordResults(TEST_CBC_3_PART_DIFF);
+    await recordResultsForm.waitUntilReady();
+    await recordResultsForm.selectStatus('Completed');
+    await recordResultsForm.save();
+    await labOrdersPage.expectBackOnOrdersList();
+    await labOrdersPage.expectOrderStatus(TEST_CBC_3_PART_DIFF, 'Reported');
+  });
+
+  test('Order five lab tests and take each one to a different fulfillment status', async ({ page, adultWoman }) => {
+    const addLabOrdersPage = await O2AddLabOrdersPage.open(page, adultWoman);
+    await addLabOrdersPage.selectCategory('Haematology');
+    await addLabOrdersPage.selectLabTest(TEST_CBC_3_PART_DIFF);
+    await addLabOrdersPage.selectLabTest(TEST_CBC_5_PART_DIFF);
+    await addLabOrdersPage.selectLabTest(TEST_COAGULATION_PROFILE);
+    await addLabOrdersPage.selectCategory('Biochemistry');
+    await addLabOrdersPage.selectLabTest(TEST_LIPID_PROFILE);
+    await addLabOrdersPage.selectLabTest(TEST_LIVER_FUNCTION);
+    await addLabOrdersPage.expectDraftOrderCount(5);
+    await addLabOrdersPage.save();
+    await addLabOrdersPage.expectOrdersSaved();
+
+    const labOrdersPage = await O2LabOrdersPage.open(page);
+    await labOrdersPage.filterByPatient(adultWoman);
+    await labOrdersPage.expectOrderCount(5);
+    await labOrdersPage.expectOrderStatuses({
+      [TEST_CBC_3_PART_DIFF]: 'Ordered',
+      [TEST_CBC_5_PART_DIFF]: 'Ordered',
+      [TEST_COAGULATION_PROFILE]: 'Ordered',
+      [TEST_LIPID_PROFILE]: 'Ordered',
+      [TEST_LIVER_FUNCTION]: 'Ordered',
+    });
+
+    await labOrdersPage.switchToGroupByPatient();
+    await labOrdersPage.expectPatientStatus(adultWoman, 'All Ordered');
+
+    // Bulk specimen collection is only reachable from the patient group row. All five orders come
+    // pre-selected; collect three of them.
+    const specimenCollectionForm = await labOrdersPage.collectSpecimenForPatient(adultWoman);
+    await specimenCollectionForm.waitUntilReady();
+    await specimenCollectionForm.expectOrderSelected(TEST_CBC_3_PART_DIFF, true);
+    await specimenCollectionForm.uncheckOrder(TEST_CBC_5_PART_DIFF);
+    await specimenCollectionForm.uncheckOrder(TEST_COAGULATION_PROFILE);
+    await specimenCollectionForm.fillLabId(`E2E Test ${Date.now()}`);
+    await specimenCollectionForm.save();
+    await labOrdersPage.expectBackOnOrdersList();
+
+    await labOrdersPage.switchToGroupByOrder();
+    await labOrdersPage.expectOrderStatuses({
+      [TEST_CBC_3_PART_DIFF]: 'Collected',
+      [TEST_LIPID_PROFILE]: 'Collected',
+      [TEST_LIVER_FUNCTION]: 'Collected',
+      [TEST_CBC_5_PART_DIFF]: 'Ordered',
+      [TEST_COAGULATION_PROFILE]: 'Ordered',
+    });
+
+    await labOrdersPage.switchToGroupByPatient();
+    await labOrdersPage.expectPatientStatus(adultWoman, 'Mixed');
+    await labOrdersPage.switchToGroupByOrder();
+
+    // Two of the collected orders get results reported.
+    for (const labTestName of [TEST_CBC_3_PART_DIFF, TEST_LIPID_PROFILE]) {
+      const recordResultsForm = await labOrdersPage.recordResults(labTestName);
+      await recordResultsForm.waitUntilReady();
+      await recordResultsForm.selectStatus('Completed');
+      await recordResultsForm.save();
+      await labOrdersPage.expectBackOnOrdersList();
+      await labOrdersPage.expectOrderStatus(labTestName, 'Reported');
+    }
+
+    // The third collected order is marked not performed. A collected order offers no "Mark as Not
+    // Collected" action, so this transition runs through the results form's Lab Status instead.
+    const notPerformedResultsForm = await labOrdersPage.recordResults(TEST_LIVER_FUNCTION);
+    await notPerformedResultsForm.waitUntilReady();
+    await notPerformedResultsForm.selectStatus('Not performed');
+    await notPerformedResultsForm.selectReasonNotPerformed(NOT_PERFORMED_REASON);
+    await notPerformedResultsForm.save();
+    await labOrdersPage.expectBackOnOrdersList();
+    await labOrdersPage.expectOrderStatus(TEST_LIVER_FUNCTION, 'Not Performed');
+
+    // One of the still-ordered tests is cancelled from the patient's own lab orders page.
+    const patientLabOrdersPage = await O2PatientLabOrdersPage.open(page, adultWoman);
+    await patientLabOrdersPage.cancelOrder(TEST_CBC_5_PART_DIFF);
+
+    const labOrdersPageAfterCancel = await O2LabOrdersPage.open(page);
+    await labOrdersPageAfterCancel.filterByPatient(adultWoman);
+    await labOrdersPageAfterCancel.expectOrderStatus(TEST_CBC_5_PART_DIFF, 'Canceled');
+    await labOrdersPageAfterCancel.switchToGroupByPatient();
+    await labOrdersPageAfterCancel.expandPatientRow(adultWoman);
+    await labOrdersPageAfterCancel.expectPatientSubRowStatus(adultWoman, TEST_CBC_5_PART_DIFF, 'Canceled');
+    await labOrdersPageAfterCancel.switchToGroupByOrder();
+
+    // The last still-ordered test goes straight from Ordered to Not Performed.
+    const notCollectedForm = await labOrdersPageAfterCancel.markAsNotCollected(TEST_COAGULATION_PROFILE);
+    await notCollectedForm.waitUntilReady();
+    await notCollectedForm.selectReason(NOT_COLLECTED_REASON);
+    await notCollectedForm.save();
+    await labOrdersPageAfterCancel.expectBackOnOrdersList();
+
+    await labOrdersPageAfterCancel.expectOrderStatuses({
+      [TEST_CBC_3_PART_DIFF]: 'Reported',
+      [TEST_LIPID_PROFILE]: 'Reported',
+      [TEST_LIVER_FUNCTION]: 'Not Performed',
+      [TEST_CBC_5_PART_DIFF]: 'Canceled',
+      [TEST_COAGULATION_PROFILE]: 'Not Performed',
+    });
+  });
+});

--- a/packages/esm-commons-app/src/ward-app/inborn-outborn-tag-row.scss
+++ b/packages/esm-commons-app/src/ward-app/inborn-outborn-tag-row.scss
@@ -28,7 +28,6 @@
   z-index: 2; // sit above the card's clickable overlay (::before, z-index 1)
   margin: 0 !important; // neutralize blanket child margins applied by some card containers
   pointer-events: none; // let clicks fall through to the underlying card button
-
 }
 
 // The origin badge, rendered as the design's fully-rounded pill.


### PR DESCRIPTION
## Summary

Two test cases to:
- Make one order for a patient, collect specimen, and mark it as completed.
- Make multiple (5) orders for a patient, and go through various order status transitions:
  - ordered -> collected -> reported
  - ordered -> not performed
  - ordered -> collected -> not performed

This is almost entirely generated by Claude. Some of the code comment feel extraneous, but I think they are helpful to the AI.

## Screenshots

## Related Issue
